### PR TITLE
sphinx docs for each plugin command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,6 @@ deploy-docs: stage-docs
 
 clean-docs:
 	@rm -rf build/sphinx/*
-	@make -C docs clean
 
 
 .PHONY: all archive clean default docs deploy-docs overview packaging-build packaging-test rpm srpm stage-docs test

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -1,0 +1,48 @@
+Koji Smoky Dingo Commands
+=========================
+
+Koji Smoky Dingo provides a number of additional commands to the
+koji CLI.
+
+
+Informational Commands
+----------------------
+
+These read-only commands gather and display information from Koji, and
+do not require any special permissions to run.
+
+.. toctree::
+   :maxdepth: 1
+
+   commands/affected-targets
+   commands/check-hosts
+   commands/client-config
+   commands/filter-builds
+   commands/latest-archives
+   commands/list-build-archives
+   commands/list-cgs
+   commands/list-component-builds
+   commands/list-env-vars
+   commands/list-rpm-macros
+   commands/list-tag-extras
+   commands/perminfo
+   commands/userinfo
+
+
+Administrative Commands
+-----------------------
+
+These commands modify aspects of Koji and are subsequently gated
+behind some level of administrative permission.
+
+See `Koji's Permission System - Administration <https://docs.pagure.org/koji/permissions/#administration>`_
+
+.. toctree::
+   :maxdepth: 1
+
+   commands/renum-tag-inheritance
+   commands/set-env-var
+   commands/set-rpm-macro
+   commands/swap-tag-inheritance
+   commands/unset-env-var
+   commands/unset-rpm-macro

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -1,12 +1,12 @@
-Koji Smoky Dingo Commands
-=========================
+Plugin Commands
+===============
 
 Koji Smoky Dingo provides a number of additional commands to the
 koji CLI.
 
 
-Informational Commands
-----------------------
+Informational
+-------------
 
 These read-only commands gather and display information from Koji, and
 do not require any special permissions to run.
@@ -29,8 +29,8 @@ do not require any special permissions to run.
    commands/userinfo
 
 
-Administrative Commands
------------------------
+Administrative
+--------------
 
 These commands modify aspects of Koji and are subsequently gated
 behind some level of administrative permission.

--- a/docs/commands/affected-targets.rst
+++ b/docs/commands/affected-targets.rst
@@ -1,0 +1,40 @@
+koji affected-targets
+=====================
+
+.. parsed-literal::
+
+ usage: koji affected-targets [-h] [-q] [-i | -b] TAGNAME [TAGNAME ...]
+
+ Show targets impacted by changes to the given tag(s)
+
+ positional arguments:
+   TAGNAME           Tag to check
+
+ optional arguments:
+   -h, --help        show this help message and exit
+   -q, --quiet       Don\'t print summary information
+   -i, --info        Print target name, build tag name, dest tag name
+   -b, --build-tags  Print build tag names rather than target names
+
+
+This command uses reversed tag inheritance to discover what targets
+are inheriting (and are therefore affected by changes to) a given list
+of tags.
+
+When the ``--build-tags`` option is specified, then rather than
+outputting a list of target names, the underlying build tag names are
+displayed instead. This behavior is similar to ``koji
+list-tag-inheritance --reverse`` but with additional filtering so that
+only the child tags that are used in a target are displayed.
+
+This can help an administrator to identify where the changes they make
+may impact different target configurations -- ie. it helps to answer
+the question "who will be having a bad day due to my changes to this
+tag?"
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.tags.AffectedTargets`
+* :py:func:`kojismokydingo.cli.tags.cli_affected_targets`

--- a/docs/commands/affected-targets.rst
+++ b/docs/commands/affected-targets.rst
@@ -2,6 +2,7 @@ koji affected-targets
 =====================
 
 .. highlight:: none
+
 ::
 
  usage: koji affected-targets [-h] [-q] [-i | -b] TAGNAME [TAGNAME ...]

--- a/docs/commands/affected-targets.rst
+++ b/docs/commands/affected-targets.rst
@@ -1,7 +1,8 @@
 koji affected-targets
 =====================
 
-.. parsed-literal::
+.. highlight:: none
+::
 
  usage: koji affected-targets [-h] [-q] [-i | -b] TAGNAME [TAGNAME ...]
 
@@ -12,7 +13,7 @@ koji affected-targets
 
  optional arguments:
    -h, --help        show this help message and exit
-   -q, --quiet       Don\'t print summary information
+   -q, --quiet       Don't print summary information
    -i, --info        Print target name, build tag name, dest tag name
    -b, --build-tags  Print build tag names rather than target names
 

--- a/docs/commands/check-hosts.rst
+++ b/docs/commands/check-hosts.rst
@@ -2,6 +2,7 @@ koji check-hosts
 ================
 
 .. highlight:: none
+
 ::
 
  usage: koji check-hosts [-h] [--timeout TIMEOUT] [--channel CHANNEL]

--- a/docs/commands/check-hosts.rst
+++ b/docs/commands/check-hosts.rst
@@ -1,13 +1,14 @@
 koji check-hosts
 ================
 
-.. parsed-literal::
+.. highlight:: none
+::
 
  usage: koji check-hosts [-h] [--timeout TIMEOUT] [--channel CHANNEL]
                          [--arch ARCHES] [--ignore IGNORE]
                          [--ignore-file IGNORE_FILE] [-q] [-s]
 
- Show enabled builders which aren\'t checking in
+ Show enabled builders which aren't checking in
 
  optional arguments:
    -h, --help            show this help message and exit

--- a/docs/commands/client-config.rst
+++ b/docs/commands/client-config.rst
@@ -2,6 +2,7 @@ koji client-config
 ==================
 
 .. highlight:: none
+
 ::
 
  usage: koji client-config [-h] [--quiet | --json | --cfg]

--- a/docs/commands/client-config.rst
+++ b/docs/commands/client-config.rst
@@ -1,7 +1,8 @@
 koji client-config
 ==================
 
-.. parsed-literal::
+.. highlight:: none
+::
 
  usage: koji client-config [-h] [--quiet | --json | --cfg]
                            [SETTING [SETTING ...]]

--- a/docs/commands/filter-builds.rst
+++ b/docs/commands/filter-builds.rst
@@ -1,7 +1,9 @@
 koji filter-builds
 ==================
 
-.. parsed-literal::
+
+.. highlight:: none
+::
 
  usage: koji filter-builds [-h] [--lookaside LOOKASIDE]
                            [--shallow-lookaside SHALLOW_LOOKASIDE]

--- a/docs/commands/latest-archives.rst
+++ b/docs/commands/latest-archives.rst
@@ -1,7 +1,8 @@
 koji latest-archives
 ====================
 
-.. parsed-literal::
+.. highlight:: none
+::
 
  usage: koji latest-archives [-h] [--json] [--urls]
                              [--build-type TYPE | --rpm | --maven | --image | --win]

--- a/docs/commands/latest-archives.rst
+++ b/docs/commands/latest-archives.rst
@@ -2,6 +2,7 @@ koji latest-archives
 ====================
 
 .. highlight:: none
+
 ::
 
  usage: koji latest-archives [-h] [--json] [--urls]

--- a/docs/commands/list-build-archives.rst
+++ b/docs/commands/list-build-archives.rst
@@ -1,0 +1,56 @@
+koji list-build-archives
+========================
+
+.. highlight:: none
+
+::
+
+ usage: koji list-build-archives [-h] [--json] [--urls]
+                                 [--build-type TYPE | --rpm | --maven | --image | --win]
+                                 [--archive-type EXT] [--key KEY] [--unsigned]
+                                 NVR
+
+ List archives from a build
+
+ positional arguments:
+   NVR                   The NVR containing the archives
+
+ optional arguments:
+   -h, --help            show this help message and exit
+   --json                Output archive information as JSON
+   --urls, -U            Present archives as URLs using the configured topurl.
+                         Default: use the configured topdir
+
+ Build Filtering Options:
+   --build-type TYPE     Only show archives for the given build type. Example
+                         types are rpm, maven, image, win. Default: show all
+                         archives.
+   --rpm                 --build-type=rpm
+   --maven               --build-type=maven
+   --image               --build-type=image
+   --win                 --build-type=win
+
+ Archive Filtering Options:
+   --archive-type EXT, -a EXT
+                         Only show archives with the given archive type. Can be
+                         specified multiple times. Default: show all
+
+ RPM Options:
+   --key KEY, -k KEY     Only show RPMs signed with the given key. Can be
+                         specified multiple times to indicate any of the keys
+                         is valid. Preferrence is in order defined. Default:
+                         show unsigned RPMs
+   --unsigned            Allow unsigned copies if no signed copies are found
+                         when --key=KEY is specified. Otherwise if keys are
+                         specified, then only RPMs signed with one of those
+                         keys are shown.
+
+
+Print paths for archives and RPMs attached to a build
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.archives.ListBuildArchives`
+* :py:func:`kojismokydingo.cli.archives.cli_list_build_archives`

--- a/docs/commands/list-cgs.rst
+++ b/docs/commands/list-cgs.rst
@@ -1,0 +1,28 @@
+koji list-cgs
+=============
+
+.. highlight:: none
+
+::
+
+ usage: koji list-cgs [-h] [--name NAME] [--json]
+
+ List content generators and their users
+
+ optional arguments:
+   -h, --help   show this help message and exit
+   --name NAME  Only show the given content generator
+   --json       Output information as JSON
+
+
+This command will display the names of content generators that have
+been registered with the given koji instance. It will also list the
+user accounts which have been granted permission to perform cg-imports
+on behalf of that content generator.
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.users.ListCGs`
+* :py:func:`kojismokydingo.cli.users.cli_list_cgs`

--- a/docs/commands/list-component-builds.rst
+++ b/docs/commands/list-component-builds.rst
@@ -1,23 +1,24 @@
-koji filter-builds
-==================
-
+koji list-component-builds
+==========================
 
 .. highlight:: none
 
 ::
 
- usage: koji filter-builds [-h] [--lookaside LOOKASIDE]
-                           [--shallow-lookaside SHALLOW_LOOKASIDE]
-                           [--limit LIMIT] [--shallow-limit SHALLOW_LIMIT]
-                           [--type BTYPES] [-c CG_NAME]
-                           [--imports | --no-imports] [-f NVR_FILE] [--tag TAG]
-                           [--inherit] [--latest] [--nvr-sort | --id-sort]
-                           [nvr [nvr ...]]
+ usage: koji list-component-builds [-h] [--lookaside LOOKASIDE]
+                                   [--shallow-lookaside SHALLOW_LOOKASIDE]
+                                   [--limit LIMIT]
+                                   [--shallow-limit SHALLOW_LIMIT]
+                                   [--type BTYPES] [-c CG_NAME]
+                                   [--imports | --no-imports] [-f NVR_FILE]
+                                   [--tag TAG] [--inherit] [--latest]
+                                   [--nvr-sort | --id-sort]
+                                   [nvr [nvr ...]]
 
- Filter a list of NVRs by various criteria
+ List a build's component dependencies
 
  positional arguments:
-   nvr
+   nvr                   Build NVR to list components of
 
  optional arguments:
    -h, --help            show this help message and exit
@@ -45,25 +46,21 @@ koji filter-builds
    --imports             Limit to imported builds
    --no-imports          Invert the imports checking
 
- Working from tagged builds:
-   --tag TAG             Filter using the builds in this tag
+ Components of tagged builds:
+   --tag TAG             Look for components of builds in this tag
    --inherit             Follow inheritance
    --latest              Limit to latest builds
 
- Sorting of output builds:
+ Sorting of builds:
    --nvr-sort            Sort output by NVR in ascending order
    --id-sort             Sort output by Build ID in ascending order
 
 
-Given a list of NVRs, output only those which match a set of filtering
-parameters.
-
-The NVR list can also come from the contents of a tag.
+This command identifies the builds used to produce another build.
 
 
 References
 ----------
 
-* :py:obj:`kojismokydingo.builds.BuildFilter`
-* :py:obj:`kojismokydingo.cli.builds.FilterBuilds`
-* :py:func:`kojismokydingo.cli.builds.cli_filter_builds`
+* :py:obj:`kojismokydingo.cli.builds.ListComponents`
+* :py:func:`kojismokydingo.cli.builds.cli_list_components`

--- a/docs/commands/list-env-vars.rst
+++ b/docs/commands/list-env-vars.rst
@@ -1,0 +1,32 @@
+koji list-env-vars
+==================
+
+.. highlight:: none
+
+::
+
+ usage: koji list-env-vars [-h] [--target]
+                           [--quiet | --sh-declaration | --json]
+                           TAGNAME
+
+ Show mock environment variables for a tag
+
+ positional arguments:
+   TAGNAME               Name of tag
+
+ optional arguments:
+   -h, --help            show this help message and exit
+   --target              Specify by target rather than a tag
+   --quiet, -q           Omit headings
+   --sh-declaration, -d  Output as sh variable declarations
+   --json                Output as JSON
+
+
+See also :ref:`koji set-env-var`, :ref:`koji unset-env-var`
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.tags.ListEnvVars`
+* :py:func:`kojismokydingo.cli.tags.cli_list_env_vars`

--- a/docs/commands/list-rpm-macros.rst
+++ b/docs/commands/list-rpm-macros.rst
@@ -1,0 +1,56 @@
+koji list-rpm-macros
+====================
+
+.. highlight:: none
+
+::
+
+ usage: koji list-rpm-macros [-h] [--target]
+                             [--quiet | --macro-definition | --json]
+                             TAGNAME
+
+ Show RPM Macros for a tag
+
+ positional arguments:
+   TAGNAME               Name of tag
+
+ optional arguments:
+   -h, --help            show this help message and exit
+   --target              Specify by target rather than a tag
+   --quiet, -q           Omit headings
+   --macro-definition, -d
+                         Output as RPM macro definitions
+   --json                Output as JSON
+
+
+Koji 1.18 and later support defining RPM macros via mock as part of a
+tag's configuration metadata.
+
+This command presents a filtered view of the tag's extras field,
+limited to just those extra settings prefixed with ``rpm.macro.``
+
+If the ``--macro-definition`` option is given, then the settings will be
+displayed in the normal format of RPM macro definitions, eg.
+
+::
+
+ [nowhere]$ koji list-rpm-macros ruby-1.9.3-el6-build
+ Macro  Value    Tag
+ -----  -------  -----------------------
+ dist   .el6     epel-6-build
+ scl    ruby193  ruby-1.9.3-el6-build
+
+ [nowhere]$ koji list-rpm-macros -d ruby-1.9.3-el6-build
+ %dist .el6
+ %scl ruby193
+
+
+See also :ref:`koji set-rpm-macro`, :ref:`koji unset-rpm-macro`
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.tags.ListRPMMacros`
+* :py:func:`kojismokydingo.cli.tags.cli_list_rpm_macros`
+* :py:func:`kojismokydingo.tags.collect_tag_extras`

--- a/docs/commands/list-tag-extras.rst
+++ b/docs/commands/list-tag-extras.rst
@@ -19,6 +19,10 @@ koji list-tag-extras
    --json       Output as JSON
 
 
+Provides a list of tag extra settings, displaying the name and value
+and the tag which provided the setting.
+
+
 References
 ----------
 

--- a/docs/commands/list-tag-extras.rst
+++ b/docs/commands/list-tag-extras.rst
@@ -1,0 +1,26 @@
+koji list-tag-extras
+====================
+
+.. highlight:: none
+
+::
+
+ usage: koji list-tag-extras [-h] [--target] [--quiet | --json] TAGNAME
+
+ Show extra settings for a tag
+
+ positional arguments:
+   TAGNAME      Name of tag
+
+ optional arguments:
+   -h, --help   show this help message and exit
+   --target     Specify by target rather than a tag
+   --quiet, -q  Omit headings
+   --json       Output as JSON
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.tags.ListTagExtras`
+* :py:func:`kojismokydingo.cli.tags.cli_list_tag_extras`

--- a/docs/commands/perminfo.rst
+++ b/docs/commands/perminfo.rst
@@ -1,0 +1,32 @@
+koji perminfo
+=============
+
+.. highlight:: none
+
+::
+
+ usage: koji perminfo [-h] [--verbose] [--by-date] [--json] PERMISSION
+
+ Show information about a permission
+
+ positional arguments:
+   PERMISSION     Name of permission
+
+ optional arguments:
+   -h, --help     show this help message and exit
+   --verbose, -v  Also show who granted the permission and when
+   --by-date, -d  Sory users by date granted. Otherwise, sort by name
+   --json         Output information as JSON
+
+
+Provides information about a permission, including which users are
+granted it. When ``--verbose`` mode is enabled, will also indicate
+what user granted the permission to them, and when.
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.users.PermissionInfo`
+* :py:func:`kojismokydingo.cli.users.cli_perminfo`
+* :py:func:`kojismokydingo.users.collect_perminfo`

--- a/docs/commands/renum-tag-inheritance.rst
+++ b/docs/commands/renum-tag-inheritance.rst
@@ -1,0 +1,45 @@
+koji renum-tag-inheritance
+==========================
+
+.. highlight:: none
+
+::
+
+ usage: koji renum-tag-inheritance [-h] [--verbose] [--test] [--begin BEGIN]
+                                   [--step STEP]
+                                   TAGNAME
+
+ Renumbers inheritance priorities of a tag, preserving order
+
+ positional arguments:
+   TAGNAME               Tag to renumber
+
+ optional arguments:
+   -h, --help            show this help message and exit
+   --verbose, -v         Print information about what's changing
+   --test, -t            Calculate the new priorities, but don't commit the
+                         changes
+   --begin BEGIN, -b BEGIN
+                         New priority for first inheritance link (default: 10)
+   --step STEP, -s STEP  Priority increment for each subsequent inheritance
+                         link after the first (default: 10)
+
+
+When you've been modifying a tag inheritance after repeated edits over
+time, you may find that there's an insufficient gap between two
+inherited parent priority values to fit another parent.
+
+This command will adjust the priority values of a tag's immediate
+parents such that they are in the same order, but are evenly spaced
+out. Those familiar with Basic may recall the ``RENUM`` command.
+
+This command requires either the ``admin`` or ``tag`` permission,
+as it modifies tag configuration data.
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.tags.RenumTagInheritance`
+* :py:func:`kojismokydingo.cli.tags.cli_renum_tag`
+* :py:func:`kojismokydingo.tags.renum_inheritance`

--- a/docs/commands/set-env-var.rst
+++ b/docs/commands/set-env-var.rst
@@ -19,7 +19,7 @@ koji set-env-var
    --target    Specify by target rather than a tag
 
 
-This permission requires either the ``admin`` or ``tag`` permission,
+This command requires either the ``admin`` or ``tag`` permission,
 as it modifies tag configuration data.
 
 See also :ref:`koji list-env-vars`, :ref:`koji unset-env-var`

--- a/docs/commands/set-env-var.rst
+++ b/docs/commands/set-env-var.rst
@@ -1,0 +1,32 @@
+koji set-env-var
+================
+
+.. highlight:: none
+
+::
+
+ usage: koji set-env-var [-h] [--target] TAGNAME var [value]
+
+ Set a mock environment variable on a tag
+
+ positional arguments:
+   TAGNAME     Name of tag
+   var         Name of the environment variable
+   value       Value of the environment var. Default: ''
+
+ optional arguments:
+   -h, --help  show this help message and exit
+   --target    Specify by target rather than a tag
+
+
+This permission requires either the ``admin`` or ``tag`` permission,
+as it modifies tag configuration data.
+
+See also :ref:`koji list-env-vars`, :ref:`koji unset-env-var`
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.tags.SetEnvVar`
+* :py:func:`kojismokydingo.cli.tags.cli_set_env_var`

--- a/docs/commands/set-rpm-macro.rst
+++ b/docs/commands/set-rpm-macro.rst
@@ -1,0 +1,50 @@
+koji set-rpm-macro
+==================
+
+.. highlight:: none
+
+::
+
+ usage: koji set-rpm-macro [-h] [--target] TAGNAME macro [value]
+
+ Set an RPM Macro on a tag
+
+ positional arguments:
+   TAGNAME     Name of tag
+   macro       Name of the macro
+   value       Value of the macro. Default: %nil
+
+ optional arguments:
+   -h, --help  show this help message and exit
+   --target    Specify by target rather than a tag
+
+
+Defines an RPM macro on a tag.
+
+The underlying tag extra setting will be constructed with the prefix
+``rpm.macro.`` and the macro name (minus any leading ``%``)
+
+Empty RPM macro values are not permitted. The closest is ``%nil``
+which is the default if no value is specified.
+
+Note that RPM macros definitioned in this manner will take precedence
+over any other definitions that may be provided by installed packages
+in the buildroot.
+
+These settings are inheritable, and there is currently no way to block
+the inheritance of such a setting, so care must be taken not to
+unintentionally pollute child build tags with settings they should not
+have. When in doubt, use :ref:`koji affected-targets` to see what
+build configurations may be impacted by any macro definitions.
+
+This command requires either the ``admin`` or ``tag`` permission,
+as it modifies tag configuration data.
+
+See also :ref:`koji list-rpm-macros`, :ref:`koji unset-rpm-macro`
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.tags.SetRPMMacro`
+* :py:func:`kojismokydingo.cli.tags.cli_set_rpm_macro`

--- a/docs/commands/swap-tag-inheritance.rst
+++ b/docs/commands/swap-tag-inheritance.rst
@@ -30,6 +30,9 @@ If the new parent is not already in the direct inheritance of the tag,
 then the old parent will be removed and new parent will be set in its
 place at the same priority.
 
+This command requires either the ``admin`` or ``tag`` permission,
+as it modifies tag configuration data.
+
 
 References
 ----------

--- a/docs/commands/swap-tag-inheritance.rst
+++ b/docs/commands/swap-tag-inheritance.rst
@@ -1,0 +1,38 @@
+koji swap-tag-inheritance
+=========================
+
+.. highlight:: none
+
+::
+
+ usage: koji swap-tag-inheritance [-h] [--verbose] [--test]
+                                  TAGNAME OLD_PARENT_TAG NEW_PARENT_TAG
+
+ Swap a tag's inheritance
+
+ positional arguments:
+   TAGNAME         Name of tag to modify
+   OLD_PARENT_TAG  Old parent tag's name
+   NEW_PARENT_TAG  New parent tag's name
+
+ optional arguments:
+   -h, --help      show this help message and exit
+   --verbose, -v   Print information about what's changing
+   --test, -t      Calculate the new inheritance, but don't commit the changes.
+
+
+Swaps the parent inheritence of a tag.
+
+If the new and old parents are both already in the direct inheritance
+of the tag, then their priorities will be swapped.
+
+If the new parent is not already in the direct inheritance of the tag,
+then the old parent will be removed and new parent will be set in its
+place at the same priority.
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.tags.SwapTagInheritance`
+* :py:func:`kojismokydingo.cli.tags.cli_swap_inheritance`

--- a/docs/commands/unset-env-var.rst
+++ b/docs/commands/unset-env-var.rst
@@ -1,0 +1,35 @@
+koji unset-env-var
+==================
+
+.. highlight:: none
+
+::
+
+ usage: koji unset-env-var [-h] [--target] TAGNAME var
+
+ Unset a mock environment variable on a tag
+
+ positional arguments:
+   TAGNAME     Name of tag
+   var         Name of the environment variable
+
+ optional arguments:
+   -h, --help  show this help message and exit
+   --target    Specify by target rather than a tag
+
+
+Note that the definition must have been set directly on the given tag,
+and not inherited from a parent tag. There is currently no way to
+block or undefine an inherited env var definition.
+
+This command requires either the ``admin`` or ``tag`` permission,
+as it modifies tag configuration data.
+
+See also :ref:`koji list-env-vars`, :ref:`koji set-env-var`
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.tags.UnsetEnvVar`
+* :py:func:`kojismokydingo.cli.tags.cli_unset_env_var`

--- a/docs/commands/unset-rpm-macro.rst
+++ b/docs/commands/unset-rpm-macro.rst
@@ -1,0 +1,39 @@
+koji unset-rpm-macro
+====================
+
+.. highlight:: none
+
+::
+
+ usage: koji unset-rpm-macro [-h] [--target] TAGNAME macro
+
+ Unset an RPM Macro on a tag
+
+ positional arguments:
+   TAGNAME     Name of tag
+   macro       Name of the macro
+
+ optional arguments:
+   -h, --help  show this help message and exit
+   --target    Specify by target rather than a tag
+
+
+Removes an RPM macro definition from a tag.
+
+Note that the definition must have been set directly on the given tag,
+and not inherited from a parent tag. There is currently no way to
+block or undefine an inherited RPM macro definition -- the closest is
+setting it to ``%nil`` which may have undesireable side-effects as
+well.
+
+This command requires either the ``admin`` or ``tag`` permission,
+as it modifies tag configuration data.
+
+See also :ref:`koji list-rpm-macros`, :ref:`koji set-rpm-macro`
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.tags.UnsetRPMMacro`
+* :py:func:`kojismokydingo.cli.tags.cli_unset_rpm_macro`

--- a/docs/commands/userinfo.rst
+++ b/docs/commands/userinfo.rst
@@ -1,0 +1,33 @@
+koji userinfo
+=============
+
+.. highlight:: none
+
+::
+
+ usage: koji userinfo [-h] [--json] USER
+
+ Show information about a user
+
+ positional arguments:
+   USER        User name or principal
+
+ optional arguments:
+   -h, --help  show this help message and exit
+   --json      Output information as JSON
+
+
+Display information about a user. Provides their status (enabled or
+blocked), their type (user or group), their kerberos identities if
+any, and a listing of any permissions they have. If the user is
+configured to perform a CG import, this will also be presented.
+
+For groups will also show the members.
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.users.UserInfo`
+* :py:func:`kojismokydingo.cli.users.cli_userinfo`
+* :py:func:`kojismokydingo.users.collect_userinfo`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,7 @@
 
 extensions = [
     'sphinx.ext.autodoc',
-    # 'sphinx.ext.autosectionlabels',
+    'sphinx.ext.autosectionlabel',
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
     # 'numpydoc',
@@ -11,6 +11,10 @@ extensions = [
 intersphinx_mapping = {
     "python": ('https://docs.python.org/3', None),
 }
+
+
+autosectionlabel_maxdepth = 1
+autosectionlabel_prefix_document = False
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,5 +7,6 @@ Contents:
    :maxdepth: 4
 
    overview
+   commands
    kojismokydingo
    kojismokydingo/cli

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,10 @@
 Koji Smoky Dingo
 ================
 
-Contents:
+Documentation Index Table of Contents
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 2
 
    overview
    commands

--- a/docs/kojismokydingo.rst
+++ b/docs/kojismokydingo.rst
@@ -1,5 +1,5 @@
-Package kojismokydingo Contents
-===============================
+Core API Reference
+==================
 
 .. automodule:: kojismokydingo
     :members:
@@ -7,11 +7,11 @@ Package kojismokydingo Contents
     :show-inheritance:
 
 
-Submodules
-----------
+Core Modules
+------------
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 1
 
    kojismokydingo/archives
    kojismokydingo/builds

--- a/docs/kojismokydingo/cli.rst
+++ b/docs/kojismokydingo/cli.rst
@@ -1,5 +1,5 @@
-Package kojismokydingo.cli Contents
-===================================
+CLI API Reference
+=================
 
 .. automodule:: kojismokydingo.cli
     :members:
@@ -7,11 +7,11 @@ Package kojismokydingo.cli Contents
     :show-inheritance:
 
 
-Submodules
-----------
+CLI Modules
+-----------
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 1
 
    cli/archives
    cli/builds

--- a/kojismokydingo/cli/tags.py
+++ b/kojismokydingo/cli/tags.py
@@ -485,7 +485,7 @@ class SetRPMMacro(TagSmokyDingo):
                help="Name of the macro")
 
         addarg("value", action="store", nargs="?", default="%nil",
-               help="Value of the macro. Default: %nil")
+               help="Value of the macro. Default: %%nil")
 
         addarg("--target", action="store_true", default=False,
                help="Specify by target rather than a tag")


### PR DESCRIPTION
- enable automatic refs for top level sections
- adds docs for each command. Closes #33
- rename some of the API page headings to make things clearer
