### PR TITLE
refactored argument parser production for plugin commands

### DIFF
--- a/docs/commands/filter-builds.rst
+++ b/docs/commands/filter-builds.rst
@@ -6,12 +6,13 @@ koji filter-builds
 
 ::
 
- usage: koji filter-builds [-h] [--lookaside LOOKASIDE]
+ usage: koji filter-builds [-h] [-f NVR_FILE] [--tag TAG] [--inherit]
+                           [--latest] [--nvr-sort | --id-sort]
+                           [--lookaside LOOKASIDE]
                            [--shallow-lookaside SHALLOW_LOOKASIDE]
                            [--limit LIMIT] [--shallow-limit SHALLOW_LIMIT]
                            [--type BTYPES] [-c CG_NAME]
-                           [--imports | --no-imports] [-f NVR_FILE] [--tag TAG]
-                           [--inherit] [--latest] [--nvr-sort | --id-sort]
+                           [--imports | --no-imports]
                            [nvr [nvr ...]]
 
  Filter a list of NVRs by various criteria
@@ -24,6 +25,15 @@ koji filter-builds
    -f NVR_FILE, --file NVR_FILE
                          Read list of builds from file, one NVR per line.
                          Specify - to read from stdin.
+
+ Working from tagged builds:
+   --tag TAG             Filter using the builds in this tag
+   --inherit             Follow inheritance
+   --latest              Limit to latest builds
+
+ Sorting of output builds:
+   --nvr-sort            Sort output by NVR in ascending order
+   --id-sort             Sort output by Build ID in ascending order
 
  Filtering by tag:
    --lookaside LOOKASIDE
@@ -44,15 +54,6 @@ koji filter-builds
                          once.
    --imports             Limit to imported builds
    --no-imports          Invert the imports checking
-
- Working from tagged builds:
-   --tag TAG             Filter using the builds in this tag
-   --inherit             Follow inheritance
-   --latest              Limit to latest builds
-
- Sorting of output builds:
-   --nvr-sort            Sort output by NVR in ascending order
-   --id-sort             Sort output by Build ID in ascending order
 
 
 Given a list of NVRs, output only those which match a set of filtering

--- a/docs/commands/list-component-builds.rst
+++ b/docs/commands/list-component-builds.rst
@@ -5,14 +5,14 @@ koji list-component-builds
 
 ::
 
- usage: koji list-component-builds [-h] [--lookaside LOOKASIDE]
+ usage: koji list-component-builds [-h] [-f NVR_FILE] [--tag TAG] [--inherit]
+                                   [--latest] [--nvr-sort | --id-sort]
+                                   [--lookaside LOOKASIDE]
                                    [--shallow-lookaside SHALLOW_LOOKASIDE]
                                    [--limit LIMIT]
                                    [--shallow-limit SHALLOW_LIMIT]
                                    [--type BTYPES] [-c CG_NAME]
-                                   [--imports | --no-imports] [-f NVR_FILE]
-                                   [--tag TAG] [--inherit] [--latest]
-                                   [--nvr-sort | --id-sort]
+                                   [--imports | --no-imports]
                                    [nvr [nvr ...]]
 
  List a build's component dependencies
@@ -25,6 +25,15 @@ koji list-component-builds
    -f NVR_FILE, --file NVR_FILE
                          Read list of builds from file, one NVR per line.
                          Specify - to read from stdin.
+
+ Components of tagged builds:
+   --tag TAG             Look for components of builds in this tag
+   --inherit             Follow inheritance
+   --latest              Limit to latest builds
+
+ Sorting of builds:
+   --nvr-sort            Sort output by NVR in ascending order
+   --id-sort             Sort output by Build ID in ascending order
 
  Filtering by tag:
    --lookaside LOOKASIDE
@@ -45,15 +54,6 @@ koji list-component-builds
                          once.
    --imports             Limit to imported builds
    --no-imports          Invert the imports checking
-
- Components of tagged builds:
-   --tag TAG             Look for components of builds in this tag
-   --inherit             Follow inheritance
-   --latest              Limit to latest builds
-
- Sorting of builds:
-   --nvr-sort            Sort output by NVR in ascending order
-   --id-sort             Sort output by Build ID in ascending order
 
 
 This command identifies the builds used to produce another build.

--- a/kojismokydingo/cli/__init__.py
+++ b/kojismokydingo/cli/__init__.py
@@ -283,8 +283,9 @@ class SmokyDingo(object):
     * if the sub-command is invoked, then the `SmokyDingo` instance is
       called, this triggers the following:
 
-      * the `SmokyDingo.parser` method provides additional argument
-        parsing
+      * the `SmokyDingo.parser` method provides an ArgumentParser
+        instance which it then decorates with arguments by passing it
+        to `SmokyDingo.arguments`
 
       * the `SmokyDingo.validate` method provides a chance to validate
         and/or manipulate the parsed arguments
@@ -334,13 +335,18 @@ class SmokyDingo(object):
 
 
     def parser(self):
+        invoke = " ".join((basename(sys.argv[0]), self.name))
+        argp = ArgumentParser(prog=invoke, description=self.description)
+        return self.arguments(argp) or argp
+
+
+    def arguments(self, parser):
         """
-        Override to provide an ArgumentParser instance with all the
-        relevant positional arguments and options added.
+        Override to add relevant arguments to the given parser instance.
+        May return an alternative parser instance or None.
         """
 
-        invoke = " ".join((basename(sys.argv[0]), self.name))
-        return ArgumentParser(prog=invoke, description=self.description)
+        pass
 
 
     def validate(self, parser, options):

--- a/kojismokydingo/cli/archives.py
+++ b/kojismokydingo/cli/archives.py
@@ -76,10 +76,8 @@ class ArchiveDingo(AnonSmokyDingo):
     group = "info"
 
 
-    def parser(self):
+    def arguments(self, parser):
         goptions = self.goptions
-
-        parser = super(ArchiveDingo, self).parser()
 
         addarg = parser.add_argument
         addarg("--json", action="store_true", default=False,
@@ -157,8 +155,7 @@ class ListBuildArchives(ArchiveDingo):
     description = "List archives from a build"
 
 
-    def parser(self):
-        parser = super(ListBuildArchives, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("nvr", metavar="NVR",
@@ -181,8 +178,7 @@ class LatestArchives(ArchiveDingo):
     description = "List latest archives from a tag"
 
 
-    def parser(self):
-        parser = super(LatestArchives, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("tag", metavar="TAGNAME",

--- a/kojismokydingo/cli/builds.py
+++ b/kojismokydingo/cli/builds.py
@@ -173,9 +173,8 @@ class BulkTagBuilds(TagSmokyDingo):
     description = "Quickly tag a large number of builds"
 
 
-    def parser(self):
-        argp = super(BulkTagBuilds, self).parser()
-        addarg = argp.add_argument
+    def arguments(self, parser):
+        addarg = parser.add_argument
 
         addarg("tag", action="store", metavar="TAGNAME",
                help="Tag to associate builds with")
@@ -205,7 +204,7 @@ class BulkTagBuilds(TagSmokyDingo):
         addarg("--notify", action="store_true", default=False,
                help="Send tagging notifications.")
 
-        group = argp.add_argument_group("Tagging order of builds")
+        group = parser.add_argument_group("Tagging order of builds")
         group = group.add_mutually_exclusive_group()
         addarg = group.add_argument
 
@@ -219,7 +218,7 @@ class BulkTagBuilds(TagSmokyDingo):
                help="pre-sort build list by build ID, so most recently"
                " completed build is tagged last")
 
-        return argp
+        return parser
 
 
     def handle(self, options):
@@ -235,11 +234,10 @@ class BulkTagBuilds(TagSmokyDingo):
                                    strict=options.strict)
 
 
-class BuildFiltering(AnonSmokyDingo):
+class BuildFiltering():
 
 
-    def parser(self):
-        parser = super(BuildFiltering, self).parser()
+    def filtering_arguments(self, parser):
 
         grp = parser.add_argument_group("Filtering by tag")
         addarg = grp.add_argument
@@ -365,13 +363,12 @@ def cli_list_components(session, nvr_list,
         print(binfo["nvr"])
 
 
-class ListComponents(BuildFiltering):
+class ListComponents(AnonSmokyDingo, BuildFiltering):
 
     description = "List a build's component dependencies"
 
 
-    def parser(self):
-        parser = super(ListComponents, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("nvr", nargs="*",
@@ -405,6 +402,9 @@ class ListComponents(BuildFiltering):
         addarg("--id-sort", action="store_const",
                dest="sorting", const=SORT_BY_ID, default=None,
                help="Sort output by Build ID in ascending order")
+
+        # additional build filtering arguments
+        parser = self.filtering_arguments(parser)
 
         return parser
 
@@ -468,13 +468,12 @@ def cli_filter_builds(session, nvr_list,
         print(binfo["nvr"])
 
 
-class FilterBuilds(BuildFiltering):
+class FilterBuilds(AnonSmokyDingo, BuildFiltering):
 
     description = "Filter a list of NVRs by various criteria"
 
 
-    def parser(self):
-        parser = super(FilterBuilds, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("nvr", nargs="*", default=[])
@@ -507,6 +506,9 @@ class FilterBuilds(BuildFiltering):
         addarg("--id-sort", action="store_const",
                dest="sorting", const=SORT_BY_ID, default=None,
                help="Sort output by Build ID in ascending order")
+
+        # additional build filtering arguments
+        parser = self.filtering_arguments(parser)
 
         return parser
 

--- a/kojismokydingo/cli/clients.py
+++ b/kojismokydingo/cli/clients.py
@@ -74,8 +74,7 @@ class ClientConfig(AnonSmokyDingo):
     description = "Show client profile settings"
 
 
-    def parser(self):
-        parser = super(ClientConfig, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("only", nargs="*", default=(),

--- a/kojismokydingo/cli/hosts.py
+++ b/kojismokydingo/cli/hosts.py
@@ -79,9 +79,8 @@ class CheckHosts(AnonSmokyDingo):
     description = "Show enabled builders which aren't checking in"
 
 
-    def parser(self):
-        argp = super(CheckHosts, self).parser()
-        addarg = argp.add_argument
+    def arguments(self, parser):
+        addarg = parser.add_argument
 
         addarg("--timeout", action="store", default=60, type=int,
                help="Timeout in minutes before builder is considered"
@@ -110,7 +109,7 @@ class CheckHosts(AnonSmokyDingo):
                help="Only print summary when 1 or more builders are failing"
                " to check in (cron-job friendly)")
 
-        return argp
+        return parser
 
 
     def handle(self, options):

--- a/kojismokydingo/cli/tags.py
+++ b/kojismokydingo/cli/tags.py
@@ -102,9 +102,8 @@ class AffectedTargets(AnonSmokyDingo):
     description = "Show targets impacted by changes to the given tag(s)"
 
 
-    def parser(self):
-        argp = super(AffectedTargets, self).parser()
-        addarg = argp.add_argument
+    def arguments(self, parser):
+        addarg = parser.add_argument
 
         addarg("tags", nargs="+", metavar="TAGNAME",
                help="Tag to check")
@@ -112,7 +111,7 @@ class AffectedTargets(AnonSmokyDingo):
         addarg("-q", "--quiet", action="store_true", default=None,
                help="Don't print summary information")
 
-        group = argp.add_mutually_exclusive_group()
+        group = parser.add_mutually_exclusive_group()
         addarg = group.add_argument
 
         addarg("-i", "--info", action="store_true", default=False,
@@ -121,7 +120,7 @@ class AffectedTargets(AnonSmokyDingo):
         addarg("-b", "--build-tags", action="store_true", default=False,
                help="Print build tag names rather than target names")
 
-        return argp
+        return parser
 
 
     def handle(self, options):
@@ -162,9 +161,8 @@ class RenumTagInheritance(TagSmokyDingo):
                   " preserving order"
 
 
-    def parser(self):
-        argp = super(RenumTagInheritance, self).parser()
-        addarg = argp.add_argument
+    def arguments(self, parser):
+        addarg = parser.add_argument
 
         addarg("tag", action="store", metavar="TAGNAME",
                help="Tag to renumber")
@@ -184,7 +182,7 @@ class RenumTagInheritance(TagSmokyDingo):
                help="Priority increment for each subsequent"
                " inheritance link after the first (default: 10)")
 
-        return argp
+        return parser
 
 
     def validate(self, parser, options):
@@ -293,15 +291,7 @@ class SwapTagInheritance(TagSmokyDingo):
     description = "Swap a tag's inheritance"
 
 
-    def parser(self):
-        """
-        Swaps TAG's inheritance from OLD_PARENT to NEW_PARENT, preserving
-        priority. If NEW_PARENT was already in the inheritance of TAG,
-        OLD_PARENT will be put in its place, effectively exchanging
-        the two parent priorities.
-        """
-
-        parser = super(SwapTagInheritance, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("tag", action="store", metavar="TAGNAME",
@@ -362,8 +352,7 @@ class ListRPMMacros(AnonSmokyDingo):
     description = "Show RPM Macros for a tag"
 
 
-    def parser(self):
-        parser = super(ListRPMMacros, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("tag", action="store", metavar="TAGNAME",
@@ -422,8 +411,7 @@ class UnsetRPMMacro(TagSmokyDingo):
     description = "Unset an RPM Macro on a tag"
 
 
-    def parser(self):
-        parser = super(UnsetRPMMacro, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("tag", action="store", metavar="TAGNAME",
@@ -474,8 +462,7 @@ class SetRPMMacro(TagSmokyDingo):
     description = "Set an RPM Macro on a tag"
 
 
-    def parser(self):
-        parser = super(SetRPMMacro, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("tag", action="store", metavar="TAGNAME",
@@ -522,8 +509,7 @@ class UnsetEnvVar(TagSmokyDingo):
     description = "Unset a mock environment variable on a tag"
 
 
-    def parser(self):
-        parser = super(UnsetEnvVar, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("tag", action="store", metavar="TAGNAME",
@@ -562,8 +548,7 @@ class SetEnvVar(TagSmokyDingo):
     description = "Set a mock environment variable on a tag"
 
 
-    def parser(self):
-        parser = super(SetEnvVar, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("tag", action="store", metavar="TAGNAME",
@@ -626,8 +611,7 @@ class ListEnvVars(AnonSmokyDingo):
     description = "Show mock environment variables for a tag"
 
 
-    def parser(self):
-        parser = super(ListEnvVars, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("tag", action="store", metavar="TAGNAME",
@@ -682,8 +666,7 @@ class ListTagExtras(AnonSmokyDingo):
     description = "Show extra settings for a tag"
 
 
-    def parser(self):
-        parser = super(ListTagExtras, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("tag", action="store", metavar="TAGNAME",

--- a/kojismokydingo/cli/users.py
+++ b/kojismokydingo/cli/users.py
@@ -97,8 +97,7 @@ class UserInfo(AnonSmokyDingo):
     description = "Show information about a user"
 
 
-    def parser(self):
-        parser = super(UserInfo, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("user", action="store", metavar="USER",
@@ -145,8 +144,7 @@ class PermissionInfo(AnonSmokyDingo):
     description = "Show information about a permission"
 
 
-    def parser(self):
-        parser = super(PermissionInfo, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("permission", action="store", metavar="PERMISSION",
@@ -196,8 +194,7 @@ class ListCGs(AnonSmokyDingo):
     description = "List content generators and their users"
 
 
-    def parser(self):
-        parser = super(ListCGs, self).parser()
+    def arguments(self, parser):
         addarg = parser.add_argument
 
         addarg("--name", action="store", default=None,


### PR DESCRIPTION
* add new SmokyDingo.arguments method

* SmokyDingo.parser now decorates its ArgumentParser instance by calling
  SmokyDingo.arguments

* made BuildFiltering a mixin, no longer a subclass of AnonSmokyDingo

* re-ordered the args for filter-builds and list-component-builds to put
  the filtering options last

* updated docs for filter-builds and list-component-builds to reflect
  change in options order

* Closes #40
