### PR TITLE
rework set-rpm-macro and set-env-var

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,9 @@ permission (koji >= [1.18]) or the admin permission.
 |---------|-------------|
 |`bulk—tag-builds` |Quickly tag a large amount of builds, bypassing the creation of individual tasks. |
 |`renum—tag-inheritance` |Adjust the priority values of a tag to maintain the same inheritance order, but to create an even amount of space between each entry. |
-|`set-env-var` |Sets the value of a mock environment variable on a tag. |
-|`set-rpm-macro` |Sets the value of a mock RPM macro on a tag. |
+|`set-env-var` |Sets, unsets, or blocks the value of a mock environment variable on a tag. |
+|`set-rpm-macro` |Sets, unsets, or blocks the value of a mock RPM macro on a tag. |
 |`swap—tag-inheritance` |Adjust the inheritance of a tag by replacing one entry for another. If both entries are already parents of a tag, then swap the priority of the two. |
-|`unset-env-var` |Removes a mock environment variable from a tag. |
-|`unset-rpm-macro` |Removes a mock RPM macro from a tag. |
 
 
 ## Information Commands

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -47,5 +47,10 @@ See `Koji's Permission System - Administration <https://docs.pagure.org/koji/per
    commands/set-env-var
    commands/set-rpm-macro
    commands/swap-tag-inheritance
+
+
+.. toctree::
+   :hidden:
+
    commands/unset-env-var
    commands/unset-rpm-macro

--- a/docs/commands/set-env-var.rst
+++ b/docs/commands/set-env-var.rst
@@ -5,7 +5,8 @@ koji set-env-var
 
 ::
 
- usage: koji set-env-var [-h] [--target] TAGNAME var [value]
+ usage: koji set-env-var [-h] [--remove] [--block] [--target]
+                         TAGNAME var [value]
 
  Set a mock environment variable on a tag
 
@@ -16,13 +17,15 @@ koji set-env-var
 
  optional arguments:
    -h, --help  show this help message and exit
+   --remove    Remove the environment var from the tag
+   --block     Block the environment var from the tag
    --target    Specify by target rather than a tag
 
 
 This command requires either the ``admin`` or ``tag`` permission,
 as it modifies tag configuration data.
 
-See also :ref:`koji list-env-vars`, :ref:`koji unset-env-var`
+See also :ref:`koji list-env-vars`
 
 
 References

--- a/docs/commands/set-rpm-macro.rst
+++ b/docs/commands/set-rpm-macro.rst
@@ -5,7 +5,8 @@ koji set-rpm-macro
 
 ::
 
- usage: koji set-rpm-macro [-h] [--target] TAGNAME macro [value]
+ usage: koji set-rpm-macro [-h] [--remove] [--block] [--target]
+                           TAGNAME macro [value]
 
  Set an RPM Macro on a tag
 
@@ -16,6 +17,8 @@ koji set-rpm-macro
 
  optional arguments:
    -h, --help  show this help message and exit
+   --remove    Remove the macro definition from the tag
+   --block     Block the macro definition from the tag
    --target    Specify by target rather than a tag
 
 
@@ -42,7 +45,7 @@ build configurations may be impacted by any macro definitions.
 This command requires either the ``admin`` or ``tag`` permission,
 as it modifies tag configuration data.
 
-See also :ref:`koji list-rpm-macros`, :ref:`koji unset-rpm-macro`
+See also :ref:`koji list-rpm-macros`
 
 
 References

--- a/docs/commands/unset-env-var.rst
+++ b/docs/commands/unset-env-var.rst
@@ -1,35 +1,12 @@
 koji unset-env-var
 ==================
 
-.. highlight:: none
-
-::
-
- usage: koji unset-env-var [-h] [--target] TAGNAME var
-
- Unset a mock environment variable on a tag
-
- positional arguments:
-   TAGNAME     Name of tag
-   var         Name of the environment variable
-
- optional arguments:
-   -h, --help  show this help message and exit
-   --target    Specify by target rather than a tag
-
-
-Note that the definition must have been set directly on the given tag,
-and not inherited from a parent tag. There is currently no way to
-block or undefine an inherited env var definition.
-
-This command requires either the ``admin`` or ``tag`` permission,
-as it modifies tag configuration data.
-
-See also :ref:`koji list-env-vars`, :ref:`koji set-env-var`
+This command has been removed, and replaced with a new ``--remove``
+option to :ref:`koji set-env-var`
 
 
 References
 ----------
 
-* :py:obj:`kojismokydingo.cli.tags.UnsetEnvVar`
-* :py:func:`kojismokydingo.cli.tags.cli_unset_env_var`
+* :py:obj:`kojismokydingo.cli.tags.SetEnvVar`
+* :py:func:`kojismokydingo.cli.tags.cli_set_env_var`

--- a/docs/commands/unset-rpm-macro.rst
+++ b/docs/commands/unset-rpm-macro.rst
@@ -1,39 +1,12 @@
 koji unset-rpm-macro
 ====================
 
-.. highlight:: none
-
-::
-
- usage: koji unset-rpm-macro [-h] [--target] TAGNAME macro
-
- Unset an RPM Macro on a tag
-
- positional arguments:
-   TAGNAME     Name of tag
-   macro       Name of the macro
-
- optional arguments:
-   -h, --help  show this help message and exit
-   --target    Specify by target rather than a tag
-
-
-Removes an RPM macro definition from a tag.
-
-Note that the definition must have been set directly on the given tag,
-and not inherited from a parent tag. There is currently no way to
-block or undefine an inherited RPM macro definition -- the closest is
-setting it to ``%nil`` which may have undesireable side-effects as
-well.
-
-This command requires either the ``admin`` or ``tag`` permission,
-as it modifies tag configuration data.
-
-See also :ref:`koji list-rpm-macros`, :ref:`koji set-rpm-macro`
+This command has been removed, and replaced with a new ``--remove``
+option to :ref:`koji set-rpm-macro`
 
 
 References
 ----------
 
-* :py:obj:`kojismokydingo.cli.tags.UnsetRPMMacro`
-* :py:func:`kojismokydingo.cli.tags.cli_unset_rpm_macro`
+* :py:obj:`kojismokydingo.cli.tags.SetRPMMacro`
+* :py:func:`kojismokydingo.cli.tags.cli_set_rpm_macro`

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -43,21 +43,16 @@ the admin permission.
 |                            | but to create an even amount of space   |
 |                            | between each entry.                     |
 +----------------------------+-----------------------------------------+
-| ``set-env-var``            | Sets the value of a mock environment    |
-|                            | variable on a tag.                      |
+| ``set-env-var``            | Sets, unsets, or blocks the value of a  |
+|                            | mock environment variable on a tag.     |
 +----------------------------+-----------------------------------------+
-| ``set-rpm-macro``          | Sets the value of a mock RPM macro on a |
-|                            | tag.                                    |
+| ``set-rpm-macro``          | Sets, unsets, or blocks the value of a  |
+|                            | mock RPM macro on a tag.                |
 +----------------------------+-----------------------------------------+
 | ``swap—tag-inheritance``   | Adjust the inheritance of a tag by      |
 |                            | replacing one entry for another. If     |
 |                            | both entries are already parents of a   |
 |                            | tag, then swap the priority of the two. |
-+----------------------------+-----------------------------------------+
-| ``unset-env-var``          | Removes a mock environment variable     |
-|                            | from a tag.                             |
-+----------------------------+-----------------------------------------+
-| ``unset-rpm-macro``        | Removes a mock RPM macro from a tag.    |
 +----------------------------+-----------------------------------------+
 
 Information Commands

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,6 @@ COMMANDS = {
     "set-env-var": "kojismokydingo.cli.tags:SetEnvVar",
     "set-rpm-macro": "kojismokydingo.cli.tags:SetRPMMacro",
     "swap-tag-inheritance": "kojismokydingo.cli.tags:SwapTagInheritance",
-    "unset-env-var": "kojismokydingo.cli.tags:UnsetEnvVar",
-    "unset-rpm-macro": "kojismokydingo.cli.tags:UnsetRPMMacro",
     "userinfo": "kojismokydingo.cli.users:UserInfo",
 }
 

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -41,8 +41,6 @@ ENTRY_POINTS = {
     "set-env-var": "kojismokydingo.cli.tags:SetEnvVar",
     "set-rpm-macro": "kojismokydingo.cli.tags:SetRPMMacro",
     "swap-tag-inheritance": "kojismokydingo.cli.tags:SwapTagInheritance",
-    "unset-env-var": "kojismokydingo.cli.tags:UnsetEnvVar",
-    "unset-rpm-macro": "kojismokydingo.cli.tags:UnsetRPMMacro",
     "userinfo": "kojismokydingo.cli.users:UserInfo",
 }
 

--- a/tests/packaging.sh
+++ b/tests/packaging.sh
@@ -60,8 +60,6 @@ function verify_koji_cli() {
         set-env-var
         set-rpm-macro
         swap-tag-inheritance
-        unset-env-var
-        unset-rpm-macro
         userinfo
     )
 


### PR DESCRIPTION
- Adds new `--remove` option to set-rpm-macro and set-env-var
- Adds new `--block` option to set-rpm-macro and set-env-var
- Removes the commands unset-rpm-macro and unset-env-var
- Updates entry points and docs
- Closes #46
- Blocking of macros or env vars requires Koji 1.23+
