### PR TITLE
block and remove for env-var and rpm-macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ permission (koji >= [1.18]) or the admin permission.
 
 | Command | Description |
 |---------|-------------|
+|`block-env-var` |Blocks a mock environment variable from a tag. |
+|`block-rpm-macro` |Blocks a mock RPM macro from a tag. |
 |`bulk—tag-builds` |Quickly tag a large amount of builds, bypassing the creation of individual tasks. |
+|`remove-env-var` |Removes a mock environment variable from a tag. |
+|`remove-rpm-macro` |Removes a mock RPM macro from a tag. |
 |`renum—tag-inheritance` |Adjust the priority values of a tag to maintain the same inheritance order, but to create an even amount of space between each entry. |
 |`set-env-var` |Sets, unsets, or blocks the value of a mock environment variable on a tag. |
 |`set-rpm-macro` |Sets, unsets, or blocks the value of a mock RPM macro on a tag. |

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -42,7 +42,11 @@ See `Koji's Permission System - Administration <https://docs.pagure.org/koji/per
 .. toctree::
    :maxdepth: 1
 
+   commands/block-env-var
+   commands/block-rpm-macro
    commands/bulk-tag-builds
+   commands/remove-env-var
+   commands/remove-rpm-macro
    commands/renum-tag-inheritance
    commands/set-env-var
    commands/set-rpm-macro

--- a/docs/commands/block-env-var.rst
+++ b/docs/commands/block-env-var.rst
@@ -1,0 +1,30 @@
+koji block-env-var
+==================
+
+.. highlight:: none
+
+::
+
+ usage: koji block-env-var [-h] [--target] TAGNAME var
+
+ Block a mock environment variable from a tag
+
+ positional arguments:
+   TAGNAME     Name of tag
+   var         Name of the environment variable
+
+ optional arguments:
+   -h, --help  show this help message and exit
+   --target    Specify by target rather than a tag
+
+
+This command is a convenience equivalent to ``koji set-env-var --block``
+
+See also :ref:`koji list-env-vars`, :ref:`koji set-env-var`, :ref:`koji remove-env-var`
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.tags.BlockEnvVar`
+* :py:func:`kojismokydingo.cli.tags.cli_set_env_var`

--- a/docs/commands/block-rpm-macro.rst
+++ b/docs/commands/block-rpm-macro.rst
@@ -1,0 +1,30 @@
+koji block-rpm-macro
+====================
+
+.. highlight:: none
+
+::
+
+ usage: koji block-rpm-macro [-h] [--target] TAGNAME macro
+
+ Block an RPM Macro from a tag
+
+ positional arguments:
+   TAGNAME     Name of tag
+   macro       Name of the macro to block
+
+ optional arguments:
+   -h, --help  show this help message and exit
+   --target    Specify by target rather than a tag
+
+
+This command is a convenience equivalent to ``koji set-rpm-macro --block``
+
+See also :ref:`koji list-rpm-macros`, :ref:`koji set-rpm-macro`, :ref:`koji remove-rpm-macro`
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.tags.BlockRPMMacro`
+* :py:func:`kojismokydingo.cli.tags.cli_set_rpm_macro`

--- a/docs/commands/list-tag-extras.rst
+++ b/docs/commands/list-tag-extras.rst
@@ -5,7 +5,8 @@ koji list-tag-extras
 
 ::
 
- usage: koji list-tag-extras [-h] [--target] [--quiet | --json] TAGNAME
+ usage: koji list-tag-extras [-h] [--target] [--blocked] [--quiet | --json]
+                             TAGNAME
 
  Show extra settings for a tag
 
@@ -15,6 +16,7 @@ koji list-tag-extras
  optional arguments:
    -h, --help   show this help message and exit
    --target     Specify by target rather than a tag
+   --blocked    Show blocked extras
    --quiet, -q  Omit headings
    --json       Output as JSON
 

--- a/docs/commands/remove-env-var.rst
+++ b/docs/commands/remove-env-var.rst
@@ -1,0 +1,30 @@
+koji remove-env-var
+===================
+
+.. highlight:: none
+
+::
+
+ usage: koji remove-env-var [-h] [--target] TAGNAME var
+
+ Remove a mock environment variable from a tag
+
+ positional arguments:
+   TAGNAME     Name of tag
+   var         Name of the environment variable
+
+ optional arguments:
+   -h, --help  show this help message and exit
+   --target    Specify by target rather than a tag
+
+
+This command is a convenience equivalent to ``koji set-env-var --remove``
+
+See also :ref:`koji list-env-vars`, :ref:`koji set-env-var`, :ref:`koji block-env-var`
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.tags.RemoveEnvVar`
+* :py:func:`kojismokydingo.cli.tags.cli_set_env_var`

--- a/docs/commands/remove-rpm-macro.rst
+++ b/docs/commands/remove-rpm-macro.rst
@@ -1,0 +1,30 @@
+koji remove-rpm-macro
+=====================
+
+.. highlight:: none
+
+::
+
+ usage: koji remove-rpm-macro [-h] [--target] TAGNAME macro
+
+ Remove an RPM Macro from a tag
+
+ positional arguments:
+   TAGNAME     Name of tag
+   macro       Name of the macro to remove
+
+ optional arguments:
+   -h, --help  show this help message and exit
+   --target    Specify by target rather than a tag
+
+
+This command is a convenience equivalent to ``koji set-rpm-macro --remove``
+
+See also :ref:`koji list-rpm-macros`, :ref:`koji set-rpm-macro`, :ref:`koji block-rpm-macro`
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.tags.RemoveRPMMacro`
+* :py:func:`kojismokydingo.cli.tags.cli_set_rpm_macro`

--- a/docs/commands/set-env-var.rst
+++ b/docs/commands/set-env-var.rst
@@ -22,10 +22,72 @@ koji set-env-var
    --target    Specify by target rather than a tag
 
 
-This command requires either the ``admin`` or ``tag`` permission,
-as it modifies tag configuration data.
+This command is a user-friendly alternative to using the ``koji
+edit-tag`` to define extra settings prefixed with ``rpm.mock.`` Use of
+this command requires either the ``admin`` or ``tag`` permission, as
+it is mutating tag configuration data.
+
+These settings are inheritable, so care must be taken not to
+unintentionally pollute child build tags with settings they should not
+have. When in doubt, use :ref:`koji affected-targets` to see what
+build configurations may be impacted by any macro definitions.
+
+When removing a defined environment variable, it must have been
+defined directly on the given tag (ie. not inherited from a parent
+tag).
+
+The command :ref:`koji remove-env-var` is equivalent to ``koji
+set-env-var --remove``
+
+Blocking an environment variable prevents it from being defined
+directly in the mock configuration. This is very different from
+defining it as an empty string, as this allows system-level
+definitions to be used instead. However, the ability to block tag
+extra settings (including these environment variables) requires Koji
+version 1.23 or later on the hub.
+
+The command :ref:`koji block-env-var` is equivalent to ``koji
+set-env-var --block``
 
 See also :ref:`koji list-env-vars`
+
+
+Examples
+--------
+
+.. highlight:: bash
+
+::
+
+ # The following are equivalent for setting a value for the CFLAGS
+ # environment variable
+
+ koji set-env-var my-tag-1.0-build CFLAGS=-Wno-shadow
+
+ koji set-env-var my-tag-1.0-build CFLAGS '\-Wno-shadow'
+
+ koji edit-tag my-tag-1.0-build --extra rpm.mock.CFLAGS=-Wno-shadow
+
+
+ # The following are equivalent for removing the above defined CFLAGS
+ # environment variable
+
+ koji remove-env-var my-tag-1.0-build CFLAGS
+
+ koji set-env-var my-tag-1.0-build CFLAGS --remove
+
+ koji edit-tag my-tag-1.0-build --remove-extra rpm.mock.CFLAGS
+
+
+ # The following are equivalent for blocking an inherited CFLAGS
+ # environment variable without giving it some alternative value. This
+ # feature requires koji 1.23 or greater.
+
+ koji block-env-var my-tag-1.0-build CFLAGS
+
+ koji set-env-var my-tag-1.0-build CFLAGS --block
+
+ koji edit-tag my-tag-1.0-build --block-extra rpm.mock.CFLAGS
 
 
 References

--- a/docs/commands/set-rpm-macro.rst
+++ b/docs/commands/set-rpm-macro.rst
@@ -24,7 +24,12 @@ koji set-rpm-macro
 
 Defines an RPM macro on a tag.
 
-This command is a user-friendly alternative to using `koji edit-tag` as defined in `Setting RPM Macros for Builds - Setting rpm.macro values <https://docs.pagure.org/koji/setting_rpm_macros/#setting-rpm-macro-values>`_
+This command is a user-friendly alternative to using the ``koji
+edit-tag`` command as defined in `Setting RPM Macros for Builds -
+Setting rpm.macro values
+<https://docs.pagure.org/koji/setting_rpm_macros/#setting-rpm-macro-values>`_.
+Use of this command requires either the ``admin`` or ``tag``
+permission, as it is mutating tag configuration data.
 
 The underlying tag extra setting will be constructed with the prefix
 ``rpm.macro.`` and the macro name (minus any leading ``%``)
@@ -36,16 +41,50 @@ Note that RPM macros definitioned in this manner will take precedence
 over any other definitions that may be provided by installed packages
 in the buildroot.
 
-These settings are inheritable, and there is currently no way to block
-the inheritance of such a setting, so care must be taken not to
+These settings are inheritable, so care must be taken not to
 unintentionally pollute child build tags with settings they should not
 have. When in doubt, use :ref:`koji affected-targets` to see what
 build configurations may be impacted by any macro definitions.
 
-This command requires either the ``admin`` or ``tag`` permission,
-as it modifies tag configuration data.
-
 See also :ref:`koji list-rpm-macros`
+
+
+Examples
+--------
+
+.. highlight:: bash
+
+::
+
+ # The following are equivalent for setting a value for the %dist
+ # rpm macro
+
+ koji set-env-var my-tag-1.0-build dist .el8
+
+ koji set-env-var my-tag-1.0-build %dist .el8
+
+ koji edit-tag my-tag-1.0-build --extra rpm.macro.dist=.el8
+
+
+ # The following are equivalent for removing the above defined %dist
+ # rpm macro
+
+ koji remove-env-var my-tag-1.0-build dist
+
+ koji set-env-var my-tag-1.0-build dist --remove
+
+ koji edit-tag my-tag-1.0-build --remove-extra rpm.macro.dist
+
+
+ # The following are equivalent for blocking an inherited %dist
+ # macro without giving it some alternative value. This feature
+ # requires koji 1.23 or greater.
+
+ koji block-env-var my-tag-1.0-build dist
+
+ koji set-env-var my-tag-1.0-build dist --block
+
+ koji edit-tag my-tag-1.0-build --block-extra rpm.macro.dist
 
 
 References

--- a/docs/commands/unset-env-var.rst
+++ b/docs/commands/unset-env-var.rst
@@ -1,12 +1,12 @@
 koji unset-env-var
 ==================
 
-This command has been removed, and replaced with a new ``--remove``
-option to :ref:`koji set-env-var`
+This command has been removed in version 0.9.3, and replaced with
+:ref:`koji remove-env-var`
 
 
 References
 ----------
 
-* :py:obj:`kojismokydingo.cli.tags.SetEnvVar`
+* :py:obj:`kojismokydingo.cli.tags.RemoveEnvVar`
 * :py:func:`kojismokydingo.cli.tags.cli_set_env_var`

--- a/docs/commands/unset-rpm-macro.rst
+++ b/docs/commands/unset-rpm-macro.rst
@@ -1,12 +1,12 @@
 koji unset-rpm-macro
 ====================
 
-This command has been removed, and replaced with a new ``--remove``
-option to :ref:`koji set-rpm-macro`
+This command has been removed in version 0.9.3 and replaced with
+:ref:`koji remove-rpm-macro`
 
 
 References
 ----------
 
-* :py:obj:`kojismokydingo.cli.tags.SetRPMMacro`
+* :py:obj:`kojismokydingo.cli.tags.RemoveRPMMacro`
 * :py:func:`kojismokydingo.cli.tags.cli_set_rpm_macro`

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -34,9 +34,19 @@ the admin permission.
 +----------------------------+-----------------------------------------+
 | Command                    | Description                             |
 +============================+=========================================+
+| ``block-env-var``          | Blocks a mock environment variable from |
+|                            | a tag.                                  |
++----------------------------+-----------------------------------------+
+| ``block-rpm-macro``        | Blocks a mock RPM macro from a tag.     |
++----------------------------+-----------------------------------------+
 | ``bulk—tag-builds``        | Quickly tag a large amount of builds,   |
 |                            | bypassing the creation of individual    |
 |                            | tasks.                                  |
++----------------------------+-----------------------------------------+
+| ``remove-env-var``         | Removes a mock environment variable     |
+|                            | from a tag.                             |
++----------------------------+-----------------------------------------+
+| ``remove-rpm-macro``       | Removes a mock RPM macro from a tag.    |
 +----------------------------+-----------------------------------------+
 | ``renum—tag-inheritance``  | Adjust the priority values of a tag to  |
 |                            | maintain the same inheritance order,    |

--- a/kojismokydingo.spec
+++ b/kojismokydingo.spec
@@ -165,6 +165,11 @@ Koji Smoky Dingo
 * Thu Sep 24 2020 Christopher O'Brien <obriencj@gmail.com> - 0.9.3-0
 - add iter_bulk_load generator function
 - fix exception in kojismokyding.cli.tabulate for None values
+- rename unset-env-var to remove-env-var
+- rename unset-rpm-macro to remove-rpm-macro
+- added block-env-var and block-rpm-macro (requires koji 1.23)
+- added FeatureUnavailable exception type
+- updated list-tag-extras to add a '--blocked' option
 
 * Thu Sep 24 2020 Christopher O'Brien <obriencj@gmail.com> - 0.9.2-1
 - fix issue with 'set-rpm-macro --help'

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ CLASSIFIERS = [
 
 COMMANDS = {
     "affected-targets": "kojismokydingo.cli.tags:AffectedTargets",
+    "block-env-var": "kojismokydingo.cli.tags:BlockEnvVar",
+    "block-rpm-macro": "kojismokydingo.cli.tags:BlockRPMMacro",
     "bulk-tag-builds": "kojismokydingo.cli.builds:BulkTagBuilds",
     "check-hosts": "kojismokydingo.cli.hosts:CheckHosts",
     "client-config": "kojismokydingo.cli.clients:ClientConfig",
@@ -60,6 +62,8 @@ COMMANDS = {
     "list-rpm-macros": "kojismokydingo.cli.tags:ListRPMMacros",
     "list-tag-extras": "kojismokydingo.cli.tags:ListTagExtras",
     "perminfo": "kojismokydingo.cli.users:PermissionInfo",
+    "remove-env-var": "kojismokydingo.cli.tags:RemoveEnvVar",
+    "remove-rpm-macro": "kojismokydingo.cli.tags:RemoveRPMMacro",
     "renum-tag-inheritance": "kojismokydingo.cli.tags:RenumTagInheritance",
     "set-env-var": "kojismokydingo.cli.tags:SetEnvVar",
     "set-rpm-macro": "kojismokydingo.cli.tags:SetRPMMacro",

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -23,6 +23,8 @@ from kojismokydingo.cli import (
 
 ENTRY_POINTS = {
     "affected-targets": "kojismokydingo.cli.tags:AffectedTargets",
+    "block-env-var": "kojismokydingo.cli.tags:BlockEnvVar",
+    "block-rpm-macro": "kojismokydingo.cli.tags:BlockRPMMacro",
     "bulk-tag-builds": "kojismokydingo.cli.builds:BulkTagBuilds",
     "cginfo": "kojismokydingo.cli.users:CGInfo",
     "check-hosts": "kojismokydingo.cli.hosts:CheckHosts",
@@ -37,6 +39,8 @@ ENTRY_POINTS = {
     "list-rpm-macros": "kojismokydingo.cli.tags:ListRPMMacros",
     "list-tag-extras": "kojismokydingo.cli.tags:ListTagExtras",
     "perminfo": "kojismokydingo.cli.users:PermissionInfo",
+    "remove-env-var": "kojismokydingo.cli.tags:RemoveEnvVar",
+    "remove-rpm-macro": "kojismokydingo.cli.tags:RemoveRPMMacro",
     "renum-tag-inheritance": "kojismokydingo.cli.tags:RenumTagInheritance",
     "set-env-var": "kojismokydingo.cli.tags:SetEnvVar",
     "set-rpm-macro": "kojismokydingo.cli.tags:SetRPMMacro",

--- a/tests/packaging.sh
+++ b/tests/packaging.sh
@@ -42,6 +42,8 @@ function verify_koji_cli() {
     local HELP=$(koji help)
     local EXPECTED=(
         affected-targets
+        block-env-var
+        block-rpm-macro
         bulk-tag-builds
         cginfo
         check-hosts
@@ -56,6 +58,8 @@ function verify_koji_cli() {
         list-rpm-macros
         list-tag-extras
         perminfo
+        remove-env-var
+        remove-rpm-macro
         renum-tag-inheritance
         set-env-var
         set-rpm-macro


### PR DESCRIPTION
- More refactoring for set-env-var and set-rpm-macro
- adds block-env-var and remove-env-var
- adds block-rpm-macro and remove-rpm-macro
- adds --blocked option to list-tag-extras to show blocks
- note: blocking extras requires koji 1.23
- update to docs
- Closes #50
