### PR TITLE
NVR and ID comparison filters

### DIFF
--- a/examples/sift/README.md
+++ b/examples/sift/README.md
@@ -1,0 +1,75 @@
+# Overview of Sifty Sieves Examples
+
+This is a collection of simple examples demonstrating how to use standalone
+sifty filters to work with collections of builds.
+
+
+## comparison.sift
+
+This is a simple check to see what builds are up-level or down-level compared
+to those in another tag. It uses the ksd-filter-builds standalone to make
+the filter behave like a script.
+
+```
+#! /usr/bin/env ksd-filter-builds
+
+;; declare that this filter needs a RELEASE_TAG parameter
+#param RELEASE_TAG
+
+;; unless otherwise set via the command-line --profile option, use the
+;; "koji-internal" koji profile. This profile must be present in the
+;; system or user koji configuration.
+#option --profile=koji-internal
+
+;; unless otherwise set via the command-line, the output option will
+;; be used to write out one file for each flag, containing the NVRs
+;; which have that flag set.
+#option --output=*:%.txt
+
+;; set the "obsoletes" flag on any filtered build which has an NVR
+;; less-than or equal-to the latest build of the same package in the
+;; given $RELEASE_TAG tag.
+(flag obsoletes (compare-latest-nvr <= $RELEASE_TAG))
+
+;; set the "upgrades" flag on any filtered build which has an NVR
+;; greater-than the latest build of the same package in the given
+;; $RELEASE_TAG tag.
+(flag upgrades (compare-latest-nvr > $RELEASE_TAG))
+
+;; The end.
+```
+
+Looking at the filter, we can see that there's a line declaring a
+param named `RELEASE_TAG`, and this param is then used in two sieve
+predicates.
+
+We can also see two lines declaring defaults for the `--profile`
+option and the `--output` option. These are used only if the options
+are not specified directly on the command-line when the filter is
+invoked.
+
+To construct an example, let's pretend we have a tag named
+"foo-bar-1-candidates" containing work-in-progress builds, and another
+tag named "foo-bar-1.2-released" containing released work for the 1.2
+version of the foo-bar project.
+
+
+Thus, we can run:
+```bash
+./comparison.sift \
+    --tag foo-bar-1-candidate \
+    -P RELEASE_TAG=foo-bar-1.2-released
+```
+
+This indicates that the filter should run against all of the builds
+tagged into our foo-bar-1-candidate tag. It also indicates that the value
+of the RELEASE_TAG parameter is foo-bar-1.2-released.
+
+Up to two files will be written in the current working directory based
+on this invocation. A file named "obsoletes.txt" will be written
+containing all of the NVRs from foo-bar-1-candidate which have an NVR
+less-than or equal-to the latest build of the same package in
+foo-bar-1.2-released.  A file named "upgrades.txt" will be written
+containing all of the NVRs from foo-bar-1-candidate which have an NVR
+greater-than the latest build of the same package in
+foo-bar-1.2-released.

--- a/examples/sift/comparison.sift
+++ b/examples/sift/comparison.sift
@@ -1,0 +1,26 @@
+#! /usr/bin/env ksd-filter-builds
+
+;; declare that this filter needs a RELEASE_TAG parameter
+#param RELEASE_TAG
+
+;; unless otherwise set via the command-line --profile option, use the
+;; "koji-internal" koji profile. This profile must be present in the
+;; system or user koji configuration.
+#option --profile=koji-internal
+
+;; unless otherwise set via the command-line, the output option will
+;; be used to write out one file for each flag, containing the NVRs
+;; which have that flag set.
+#option --output=*:%.txt
+
+;; set the "obsoletes" flag on any filtered build which has an NVR
+;; less-than or equal-to the latest build of the same package in the
+;; given $RELEASE_TAG tag.
+(flag obsoletes (compare-latest-nvr <= $RELEASE_TAG))
+
+;; set the "upgrades" flag on any filtered build which has an NVR
+;; greater-than the latest build of the same package in the given
+;; $RELEASE_TAG tag.
+(flag upgrades (compare-latest-nvr > $RELEASE_TAG))
+
+;; The end.

--- a/kojismokydingo/builds.py
+++ b/kojismokydingo/builds.py
@@ -113,12 +113,24 @@ class BuildNEVRCompare(object):
         return self.__cmp__(other) == 0
 
 
+    def __ne__(self, other):
+        return self.__cmp__(other) != 0
+
+
     def __lt__(self, other):
         return self.__cmp__(other) < 0
 
 
+    def __le__(self, other):
+        return self.__cmp__(other) <= 0
+
+
     def __gt__(self, other):
         return self.__cmp__(other) > 0
+
+
+    def __ge__(self, other):
+        return self.__cmp__(other) >= 0
 
 
 def build_nvr_sort(build_infos, dedup=True):

--- a/kojismokydingo/sift/builds.py
+++ b/kojismokydingo/sift/builds.py
@@ -817,6 +817,7 @@ class CompareLatestSieve(CacheMixin):
 
     def __init__(self, sifter, comparison, tag):
         op = ensure_comparison(comparison)
+        tag = ensure_str(tag)
 
         super(CompareLatestSieve, self).__init__(sifter, comparison, tag)
         self.op = op
@@ -834,7 +835,7 @@ class CompareLatestSieve(CacheMixin):
 
 
     def comparison(self, binfo, latest):
-        keyfn = self.compare_key
+        keyfn = self.comparison_key
         return self.op(keyfn(binfo), keyfn(latest))
 
 

--- a/kojismokydingo/sift/common.py
+++ b/kojismokydingo/sift/common.py
@@ -1,0 +1,154 @@
+# This library is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses/>.
+
+
+"""
+Koji Smoky Dingo - Koji-specific utilities for working with Sifty
+sieves
+
+:author: Christopher O'Brien <obriencj@gmail.com>
+:license: GPL v3
+"""
+
+
+from operator import itemgetter
+from six.moves import map
+
+from . import Sieve
+from ..builds import latest_maven_builds
+
+
+__all__ = ("CacheMixin", )
+
+
+class CacheMixin(Sieve):
+    """
+    Mixin providing some caching interfaces to various koji calls.
+    These will store cached results on the instance's sifter. The
+    cache is cleared when the sifter's `reset` method is invoked.
+    """
+
+    def _mixin_cache(self, name):
+        return self.sifter.get_cache("*mixin", name)
+
+
+    def latest_builds(self, session, tag_id, inherit=True):
+        cache = self._mixin_cache("latest_builds")
+
+        key = (tag_id, inherit)
+        found = cache.get(key)
+
+        if found is None:
+            found = session.getLatestBuilds(tag_id)
+            cache[key] = found
+
+        return found
+
+
+    def latest_build_ids(self, session, tag_id, inherit=True):
+        cache = self._mixin_cache("latest_build_ids")
+
+        key = (tag_id, inherit)
+        found = cache.get(key)
+
+        if found is None:
+            blds = self.latest_builds(session, tag_id, inherit)
+            found = cache[key] = set(map(itemgetter("id"), blds))
+
+        return found
+
+
+    def latest_builds_by_name(self, session, tag_id, inherit=True):
+        cache = self._mixin_cache("latest_builds_by_name")
+
+        key = (tag_id, inherit)
+        found = cache.get(key)
+
+        if found is None:
+            blds = self.latest_builds(session, tag_id, inherit)
+            found = cache[key] = dict((b["name"], b) for b in blds)
+
+        return found
+
+
+    def latest_maven_builds(self, session, tag_id, inherit=True):
+        cache = self._mixin_cache("latest_maven_builds")
+
+        key = (tag_id, inherit)
+        found = cache.get(key)
+
+        if found is None:
+            found = latest_maven_builds(session, tag_id, inherit=inherit)
+            cache[key] = found
+
+        return found
+
+
+    def latest_maven_build_ids(self, session, tag_id, inherit=True):
+        cache = self._mixin_cache("latest_maven_build_ids")
+
+        key = (tag_id, inherit)
+        found = cache.get(key)
+
+        if found is None:
+            blds = self.latest_maven_builds(session, tag_id, inherit)
+            found = cache[key] = set(map(itemgetter("id"), blds))
+
+        return found
+
+
+    def list_packages(self, session, tag_id, inherited=True):
+        cache = self._mixin_cache("list_packages")
+
+        key = (tag_id, inherited)
+        found = cache.get(key)
+
+        if found is None:
+            found = cache[key] = session.listPackages(tag_id, inherited=True)
+
+        return found
+
+
+    def allowed_packages(self, session, tag_id, inherited=True):
+        cache = self._mixin_cache("allowed_packages")
+
+        key = (tag_id, inherited)
+        found = cache.get(key)
+
+        if found is None:
+            found = cache[key] = set()
+
+            for pkg in self.list_packages(session, tag_id, inherited):
+                if not pkg["blocked"]:
+                    found.add(pkg["package_name"])
+
+        return found
+
+
+    def blocked_packages(self, session, tag_id, inherited=True):
+        cache = self._mixin_cache("blocked_packages")
+
+        key = (tag_id, inherited)
+        found = cache.get(key)
+
+        if found is None:
+            found = cache[key] = set()
+
+            for pkg in self.list_packages(session, tag_id, inherited):
+                if pkg["blocked"]:
+                    found.add(pkg["package_name"])
+
+        return found
+
+
+# The end.

--- a/kojismokydingo/standalone/builds.py
+++ b/kojismokydingo/standalone/builds.py
@@ -41,6 +41,18 @@ class LonelyFilterBuilds(AnonLonelyDingo, FilterBuilds):
     Adapter to make the FilterBuilds command into a LonelyDingo.
     """
 
+
+    def __init__(self, name):
+        super(LonelyFilterBuilds, self).__init__(name)
+
+        # some trickery to un-require the --profile option, though we
+        # will mimic the behavior later. We need to do this because
+        # this standalone may pull a profile out of the filter file
+        # itself. We'll make sure to fail empty profile values later
+        # in validation.
+        self.default_profile = ""
+
+
     def arguments(self, parser):
         addarg = parser.add_argument
         addarg("filter_file", metavar="FILTER_FILE",
@@ -101,6 +113,10 @@ class LonelyFilterBuilds(AnonLonelyDingo, FilterBuilds):
                 # override a define back to its default
                 # value. Something to fix later.
                 act(parser, options, val)
+
+        if not options.profile:
+            parser.error("the following arguments are required:"
+                         " --profile/-p")
 
         self.default_params().update(params)
 

--- a/tests/sift/__init__.py
+++ b/tests/sift/__init__.py
@@ -66,7 +66,7 @@ class Poke(Sieve):
 
 
     def check(self, _session, data):
-        cache = self.get_cache(data)
+        cache = self.get_info_cache(data)
         seen = cache.get("count", 0)
         cache["count"] = seen + 1
 
@@ -816,16 +816,16 @@ class SifterTest(TestCase):
         self.assertEqual(res["keep"], [TACOS, PIZZA, BEER])
         self.assertEqual(res["default"], [DRAINO])
 
-        che = sifter.get_cache("poke", TACOS)
+        che = sifter.get_info_cache("poke", TACOS)
         self.assertEqual(che["count"], 3)
 
-        che = sifter.get_cache("poke", PIZZA)
+        che = sifter.get_info_cache("poke", PIZZA)
         self.assertEqual(che["count"], 3)
 
-        che = sifter.get_cache("poke", BEER)
+        che = sifter.get_info_cache("poke", BEER)
         self.assertEqual(che["count"], 3)
 
-        che = sifter.get_cache("poke", DRAINO)
+        che = sifter.get_info_cache("poke", DRAINO)
         self.assertEqual(che["count"], 4)
 
 


### PR DESCRIPTION

- refactoring for shared caching of some koji session calls
- BuildNEVRCompare needs all the comparison magic methods
- misnamed comparison_key, and we need to ensure that the tag is a str
- some trickery to allow ksd-filter-builds to delay requiring the --profile option
- an example stand-alone sifty sieve script
- closes #62
