### PR TITLE
tag-filter command

### DIFF
--- a/.tito/packages/.readme
+++ b/.tito/packages/.readme
@@ -1,0 +1,3 @@
+the .tito/packages directory contains metadata files
+named after their packages. Each file has the latest tagged
+version and the project's relative directory.

--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -1,0 +1,5 @@
+[buildconfig]
+builder = tito.builder.Builder
+tagger = tito.tagger.ReleaseTagger
+changelog_do_not_remove_cherrypick = 0
+changelog_format = %s (%ae)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ permissions in koji.
 |`check—hosts` |Show builder hosts which haven't been checking in lately |
 |`client-config` |Show settings for client profiles |
 |`filter-builds` |Filter a list of NVRs by various criteria |
+|`filter-tags` |Filter a list of tags by various criteria |
 |`latest-archives` |Show selected latest archives from a tag |
 |`list-btypes` |Show build types |
 |`list-build-archives` |Show selected archives attached to a build |

--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -19,6 +19,7 @@ do not require any special permissions to run.
    commands/check-hosts
    commands/client-config
    commands/filter-builds
+   commands/filter-tags
    commands/latest-archives
    commands/list-btypes
    commands/list-build-archives

--- a/docs/commands/filter-builds.rst
+++ b/docs/commands/filter-builds.rst
@@ -89,7 +89,7 @@ koji filter-builds
 Given a list of NVRs, output only those which match a set of filtering
 parameters.
 
-The set of NVRs to tag can be fed to this command in multiple
+The set of NVRs to filter can be fed to this command in multiple
 ways. They can be specified as arguments, or they can be specified
 using the ``--file`` option to reference either a file containing a
 list of NVRs (one per line) or ``-`` to indicate stdin. The NVR list
@@ -125,3 +125,4 @@ References
 * :py:obj:`kojismokydingo.cli.builds.FilterBuilds`
 * :py:func:`kojismokydingo.cli.builds.cli_filter_builds`
 * :py:obj:`kojismokydingo.builds.BuildFilter`
+* :py:obj:`kojismokydingo.sift.builds`

--- a/docs/commands/filter-tags.rst
+++ b/docs/commands/filter-tags.rst
@@ -1,0 +1,87 @@
+koji filter-tags
+================
+
+
+.. highlight:: none
+
+::
+
+ usage: koji filter-tags [-h] [-f TAG_FILE] [--strict]
+                         [--search GLOB | --regex REGEX]
+                         [--nvr-sort | --id-sort] [--param KEY=VALUE]
+                         [--env-params] [--output FLAG:FILENAME]
+                         [--filter FILTER | --filter-file FILTER_FILE]
+                         [TAGNNAME [TAGNNAME ...]]
+
+ Filter a list of tags
+
+ positional arguments:
+   TAGNNAME              Tag names to filter through
+
+ optional arguments:
+   -h, --help            show this help message and exit
+   -f TAG_FILE, --file TAG_FILE
+                         Read list of tags from file, one name per line.
+                         Specify - to read from stdin.
+   --strict              Erorr if any of the tag names to not resolve into a
+                         real tag. Otherwise, missing tags are ignored.
+
+ Searching for tags:
+   --search GLOB         Filter the results of a search for tags with the given
+                         name pattern
+   --regex REGEX         Filter the results of a search for tags with the given
+                         regex name pattern
+
+ Sorting of tags:
+   --nvr-sort            Sort output by Name in ascending order
+   --id-sort             Sort output by Tag ID in ascending order
+
+ Filtering with Sifty sieves:
+   --param KEY=VALUE, -P KEY=VALUE
+                         Provide compile-time values to the sifty filter
+                         expressions
+   --env-params          Use environment vars for params left unassigned
+   --output FLAG:FILENAME, -o FLAG:FILENAME
+                         Divert results marked with the given FLAG to FILENAME.
+                         If FILENAME is '-', output to stdout. The 'default'
+                         flag is output to stdout by default, and other flags
+                         are discarded
+   --filter FILTER       Use the given sifty filter predicates
+   --filter-file FILTER_FILE
+                         Load sifty filter predictes from file
+
+
+Given a list of tag names, output only those which match a set of
+filtering parameters.
+
+The set of tags to filter can be fed to this command in multiple
+ways. They can be specified as arguments, or they can be specified by
+using the ``--file`` option to reference either a file containing a
+list of tags (one per line) or ``-`` to indicate stdin. The tag list
+can also be fed from a glob-style name search via the ``--search``
+option, or a regex-style name search via the ``--regex`` option.
+
+If no tags are given as arguments, and the ``--file`` option isn't
+specified, and stdin is detected to not be a TTY, then the list of
+tags will be read from stdin by default.
+
+
+Filtering Tags with Sifty Dingo
+-------------------------------
+
+This command supports filtering using the :ref:`Sifty Dingo Filtering
+Language`. Sieve predicates can be specified inline using the
+``--filter`` option or loaded from a file using the ``--filter-file``
+option.
+
+It's important to note that sifty dingo filtering only happens after
+the tags have been loaded from koji. The filters themselves are run
+client-side.
+
+
+References
+----------
+
+* :py:obj:`kojismokydingo.cli.tags.FilterTags`
+* :py:func:`kojismokydingo.cli.tags.cli_filter_tags`
+* :py:obj:`kojismokydingo.sift.tags`

--- a/docs/kojismokydingo/sift.rst
+++ b/docs/kojismokydingo/sift.rst
@@ -16,3 +16,4 @@ Sift Modules
    sift/builds
    sift/common
    sift/parse
+   sift/tags

--- a/docs/kojismokydingo/sift/tags.rst
+++ b/docs/kojismokydingo/sift/tags.rst
@@ -1,0 +1,7 @@
+kojismokydingo.sift.tags
+------------------------
+
+.. automodule:: kojismokydingo.sift.tags
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -89,6 +89,9 @@ permissions in koji.
 | ``filter-builds``          | Filter a list of NVRs by various        |
 |                            | criteria                                |
 +----------------------------+-----------------------------------------+
+| ``filter-tags``            | Filter a list of tags by various        |
+|                            | criteria                                |
++----------------------------+-----------------------------------------+
 | ``latest-archives``        | Show selected latest archives from a    |
 |                            | tag                                     |
 +----------------------------+-----------------------------------------+

--- a/docs/release_notes/v0.9.6.rst
+++ b/docs/release_notes/v0.9.6.rst
@@ -19,13 +19,16 @@ Otherwise, still chugging along!
 - Added a ChacheMixin to kojismokydingo.sift.common with methods that
   will cache the results of large tag queries. Sieve classes can
   inherit this to make use of the cache.
-- Added two new build sieves: compare-latest-nvr and
-  compare-latest-id. These allow for filtering builds using comparison
-  operators against the latest build of the same package in a given
-  tag.
+- Added build sieves compare-latest-nvr and compare-latest-id. These
+  allow for filtering builds using comparison operators against the
+  latest build of the same package in a given tag.
+- Added build sieve pkg-unlisted to filter builds which do not have a
+  package listing in a particular tag (neither allowed nor blocked)
 - Fixed an issue where the ksd-filter-builds standalone would still
   require the '--profile' option to be specified on the command-line
   even when the '#option --profile' directive was present in the
   filter.
 - Added 'koji open' command which will launch a browser to the info
   page for the relevant koji data type.
+- Added 'koji filter-tags' command and 'ksd-filter-tags' standalone
+  command for applying sifty predicates to filter a list of tags

--- a/docs/siftylang.rst
+++ b/docs/siftylang.rst
@@ -771,3 +771,33 @@ permission set.
 
 If any ``PERM`` patters are specified, then matches tags which have
 any of the listed permissions set.
+
+
+Tag Predicate ``pkg-allowed``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (pkg-allowed PKG [PKG...])
+
+Matches tags which have a package listing with any of the given
+``PKG`` contained therein and not blocked, honoring inheritance.
+
+
+Tag Predicate ``pkg-blocked``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (pkg-blocked PKG [PKG...])
+
+Matches tags which have a package listing with any of the given
+``PKG`` contained therein and blocked, honoring inheritance.
+
+
+Tag Predicate ``pkg-unlisted``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (pkg-unlisted PKG [PKG...])
+
+Matches tags which have no package listing (neither allowed nor
+blocked) for any of the given ``PKG`` names. Honors inheritance.

--- a/docs/siftylang.rst
+++ b/docs/siftylang.rst
@@ -644,17 +644,60 @@ symbols. Only matches tags which have the exact same set of
 architectures.
 
 
-Tag Predicate ``inherits``
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Tag Predicate ``has-ancestor``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
-   (inherits [TAG...])
+   (has-ancestor [TAG...])
+   (inherits-from [TAG...])
 
 If no ``TAG`` patterns are specified, matches tags which have any
 parents.
 
 If ``TAG`` patterns are specified, matches tags which have a parent at
 any depth matching any of the given patterns.
+
+
+Tag Predicate ``has-child``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (has-child [TAG...])
+   (parent-of [TAG...])
+
+If no ``TAG`` patterns are specified, matches tags which are the
+direct parent to any other tag.
+
+If ``TAG`` patterns are specified, matches tags which are the direct
+parent to any tag matching any of the given patterns.
+
+
+Tag Predicate ``has-descendant``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (has-descendant [TAG...])
+   (inherited-by [TAG...])
+
+If no ``TAG`` patterns are specified, matches tags which are inherited
+by any other tag.
+
+If ``TAG`` patterns are specified, matches tags which are inherited by
+any tag matching any of the patterns, at any depth.
+
+
+Tag Predicate ``has-parent``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (has-parent [TAG...])
+   (child-of [TAG...])
+
+If no ``TAG`` patterns are specified, matches tags which have any
+parents.
+
+If ``TAG`` patterns are specified, matchs tags which have any direct
+parent matching any of the given patterns.
 
 
 Tag Predicate ``locked``
@@ -674,19 +717,6 @@ Tag Predicate ``name``
 
 Matches tags which have a name that matches any of the given ``NAME``
 patterns.
-
-
-Tag Predicate ``parent``
-^^^^^^^^^^^^^^^^^^^^^^^^
-::
-
-   (parent [TAG...])
-
-If no ``TAG`` patterns are specified, matches tags which have any
-parents.
-
-If ``TAG`` patterns are specified, matchs tags which have any direct
-parent matching any of the given patterns.
 
 
 Tag Predicate ``permission``

--- a/docs/siftylang.rst
+++ b/docs/siftylang.rst
@@ -687,7 +687,7 @@ any tag matching any of the patterns, at any depth.
 
 
 Tag Predicate ``has-parent``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (has-parent [TAG...])

--- a/docs/siftylang.rst
+++ b/docs/siftylang.rst
@@ -293,8 +293,8 @@ A sifter instance with these and the core sieves available by default can be
 created via :py:func:`kojismokydingo.sift.builds.build_info_sifter`
 
 
-EVR Comparison Predicates
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Build EVR Comparison Predicates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (OP VER)
@@ -322,8 +322,8 @@ These predicates filter by using RPM EVR comparison rules against the
 epoch, version, and release values of the builds.
 
 
-Predicate ``cg-imported``
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Build Predicate ``cg-imported``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (cg-imported [CGNAME...])
@@ -336,8 +336,8 @@ If any optional ``CGNAME`` matchers are supplied, then filters for
 builds which are produced by matching content generators only.
 
 
-Predicate ``compare-latest-id``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Build Predicate ``compare-latest-id``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (compare-latest-id OP TAG)
@@ -354,8 +354,8 @@ build in the tag, then the filtered build will not be included.
 result in a `kojismokydingo.NoSuchTag` exception being raised.
 
 
-Predicate ``compare-latest-nvr``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Build Predicate ``compare-latest-nvr``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (compare-latest-nvr OP TAG)
@@ -372,8 +372,8 @@ build in the tag, then the filtered build will not be included.
 result in a `kojismokydingo.NoSuchTag` exception being raised.
 
 
-Predicate ``epoch``
-^^^^^^^^^^^^^^^^^^^^
+Build Predicate ``epoch``
+^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (epoch EPOCH [EPOCH...])
@@ -382,8 +382,8 @@ Filters for builds whose epoch value matches any of the given ``EPOCH``
 patterns.
 
 
-Predicate ``imported``
-^^^^^^^^^^^^^^^^^^^^^^
+Build Predicate ``imported``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (imported)
@@ -392,8 +392,8 @@ Filters for builds which have no task ID. These builds could be either raw
 imports or from a content generator.
 
 
-Predicate ``inherited``
-^^^^^^^^^^^^^^^^^^^^^^^
+Build Predicate ``inherited``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (inherited TAG [TAG...])
@@ -406,8 +406,8 @@ their parents.
 result in a `kojismokydingo.NoSuchTag` exception being raised.
 
 
-Predicate ``latest``
-^^^^^^^^^^^^^^^^^^^^
+Build Predicate ``latest``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (latest TAG [TAG...])
@@ -421,8 +421,8 @@ listings and blocks.
 result in a `kojismokydingo.NoSuchTag` exception being raised.
 
 
-Predicate ``latest-maven``
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Build Predicate ``latest-maven``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (latest-maven TAG [TAG...])
@@ -440,8 +440,8 @@ uniqueness is by the GAV rather than the package name.
 result in a `kojismokydingo.NoSuchTag` exception being raised.
 
 
-Predicate ``name``
-^^^^^^^^^^^^^^^^^^
+Build Predicate ``name``
+^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (name NAME [NAME...])
@@ -450,8 +450,8 @@ Filters for builds which have a name matching any of the given
 ``NAME`` patterns.
 
 
-Predicate ``nvr``
-^^^^^^^^^^^^^^^^^
+Build Predicate ``nvr``
+^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (nvr NVR [NVR...])
@@ -460,8 +460,8 @@ Filters for builds which have an NVR matching any of the given ``NVR``
 (name-version-release) patterns.
 
 
-Predicate ``owner``
-^^^^^^^^^^^^^^^^^^^
+Build Predicate ``owner``
+^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (owner USER [USER...])
@@ -473,8 +473,8 @@ this may result in a `kojismokydingo.NoSuchUser` exception being
 raised.
 
 
-Predicate ``pkg-allowed``
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Build Predicate ``pkg-allowed``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (pkg-allowed TAG [TAG...])
@@ -487,8 +487,8 @@ tags, honoring inheritance.
 result in a `kojismokydingo.NoSuchTag` exception being raised.
 
 
-Predicate ``pkg-blocked``
-^^^^^^^^^^^^^^^^^^^^^^^^^
+Build Predicate ``pkg-blocked``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (pkg-blocked TAG [TAG...])
@@ -501,8 +501,8 @@ the given tags, honoring inheritance.
 result in a `kojismokydingo.NoSuchTag` exception being raised.
 
 
-Predicate ``release``
-^^^^^^^^^^^^^^^^^^^^^
+Build Predicate ``release``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (release REL [REL...])
@@ -511,8 +511,8 @@ Filters for builds which have a release matching any of the given
 ``REL`` patterns.
 
 
-Predicate ``signed``
-^^^^^^^^^^^^^^^^^^^^
+Build Predicate ``signed``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (signed [SIGKEY...])
@@ -524,8 +524,8 @@ If no ``SIGKEY`` patterns are supplied, then filters for builds which
 have an RPM archive that has been signed with any key.
 
 
-Predicate ``state``
-^^^^^^^^^^^^^^^^^^^
+Build Predicate ``state``
+^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (state STATE [STATE...])
@@ -543,8 +543,8 @@ Valid states are:
   * ``5`` ``CANCELED``
 
 
-Predicate ``tagged``
-^^^^^^^^^^^^^^^^^^^^
+Build Predicate ``tagged``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (tagged [TAG...])
@@ -556,8 +556,8 @@ If no ``TAG`` patterns are specified, then filters for builds which
 have any tags at all.
 
 
-Predicate ``type``
-^^^^^^^^^^^^^^^^^^
+Build Predicate ``type``
+^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (type BTYPE [BTYPE...])
@@ -567,11 +567,110 @@ build types are rpm, maven, image, and win. Koji instances may support
 plugins which extend the available build types beyond these.
 
 
-Predicate ``version``
-^^^^^^^^^^^^^^^^^^^^^
+Build Predicate ``version``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (version VER [VER...])
 
 Filters for builds which have a version matching any of the given
 ``VER`` patterns.
+
+
+Tag Sieves
+----------
+
+To facilitate filtering sequences of koji tag info dicts, there are
+a number of available sieves provided in the
+`kojismokydingo.sift.tags` module.
+
+A sifter instance with these and the core sieves available by default can be
+created via :py:func:`kojismokydingo.sift.tags.tag_info_sifter`
+
+
+Tag Predicate ``arch``
+^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (arch [ARCH...])
+
+
+If no ``ARCH`` patterns are specified, matches tags which have any
+architectures at all.
+
+If ``ARCH`` patterns are specified, then only matches tags which have
+an architecture that matches any of the given patterns.
+
+
+Tag Predicate ``build-tag``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (build-tag [TARGET...])
+
+If no ``TARGET`` is specified, then matches tags which are used as the
+build tag for any target.
+
+If any ``TARGET`` patterns are specified, then matches tags which are
+used as the build tag for a target with a name matching any of the
+patterns.
+
+
+Tag Predicate ``dest-tag``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (dest-tag [TARGET...])
+
+If no ``TARGET`` is specified, then matches tags which are used as the
+destination tag for any target.
+
+If any ``TARGET`` patterns are specified, then matches tags which are
+used as the destination tag for a target with a name matching any of
+the patterns.
+
+
+Tag Predicate ``exact-arch``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (exact-arch [ARCH...])
+
+If no ``ARCH`` names are specified, matches only tags which have no
+architectures.
+
+If ``ARCH`` names are specified, they must be specified as
+symbols. Only matches tags which have the exact same set of
+architectures.
+
+
+Tag Predicate ``locked``
+^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (locked)
+
+Matches tags which have been locked.
+
+
+Tag Predicate ``name``
+^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (name NAME [NAME...])
+
+Matches tags which have a name that matches any of the given ``NAME``
+patterns.
+
+
+Tag Predicate ``permission``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (permission [PERM...])
+
+If no ``PERM`` is specified, then matches tags which have any
+permission set.
+
+If any ``PERM`` patters are specified, then matches tags which have
+any of the listed permissions set.

--- a/docs/siftylang.rst
+++ b/docs/siftylang.rst
@@ -644,6 +644,19 @@ symbols. Only matches tags which have the exact same set of
 architectures.
 
 
+Tag Predicate ``inherits``
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (inherits [TAG...])
+
+If no ``TAG`` patterns are specified, matches tags which have any
+parents.
+
+If ``TAG`` patterns are specified, matches tags which have a parent at
+any depth matching any of the given patterns.
+
+
 Tag Predicate ``locked``
 ^^^^^^^^^^^^^^^^^^^^^^^^
 ::
@@ -661,6 +674,19 @@ Tag Predicate ``name``
 
 Matches tags which have a name that matches any of the given ``NAME``
 patterns.
+
+
+Tag Predicate ``parent``
+^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (parent [TAG...])
+
+If no ``TAG`` patterns are specified, matches tags which have any
+parents.
+
+If ``TAG`` patterns are specified, matchs tags which have any direct
+parent matching any of the given patterns.
 
 
 Tag Predicate ``permission``

--- a/docs/siftylang.rst
+++ b/docs/siftylang.rst
@@ -501,6 +501,20 @@ the given tags, honoring inheritance.
 result in a `kojismokydingo.NoSuchTag` exception being raised.
 
 
+Build Predicate ``pkg-unlisted``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (pkg-unlisted TAG [TAG...])
+
+Filters for builds which have their package name unlisted (neither
+allowed nor blocked) in any of the given tags, honoring inheritance.
+
+``TAG`` may be specified by either name or ID, but not by pattern.
+``TAG`` will be validated when the sieve is first run -- this may
+result in a `kojismokydingo.NoSuchTag` exception being raised.
+
+
 Build Predicate ``release``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::

--- a/docs/siftylang.rst
+++ b/docs/siftylang.rst
@@ -602,12 +602,21 @@ A sifter instance with these and the core sieves available by default can be
 created via :py:func:`kojismokydingo.sift.tags.tag_info_sifter`
 
 
+Tag Predicate ``all-group-pkg``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (all-group-pkg GROUP PKG [PKG...])
+
+Matches tags which have the given install group, which must also
+contain all of the given ``PKG`` names
+
+
 Tag Predicate ``arch``
 ^^^^^^^^^^^^^^^^^^^^^^
 ::
 
    (arch [ARCH...])
-
 
 If no ``ARCH`` patterns are specified, matches tags which have any
 architectures at all.
@@ -683,6 +692,24 @@ architectures.
 If ``ARCH`` names are specified, they must be specified as
 symbols. Only matches tags which have the exact same set of
 architectures.
+
+
+Tag Predicate ``group``
+^^^^^^^^^^^^^^^^^^^^^^^
+::
+   (group GROUP [GROUP...])
+
+Matches tags which have any of the given install groups configured.
+Honors inheritance.
+
+
+Tag Predicate ``group-pkg``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+   (group-pkg GROUP PKG [PKG...])
+
+Matches tags which have the given install group, which also contains
+any of the given ``PKG`` names
 
 
 Tag Predicate ``has-ancestor``

--- a/docs/siftylang.rst
+++ b/docs/siftylang.rst
@@ -616,6 +616,33 @@ used as the build tag for a target with a name matching any of the
 patterns.
 
 
+Tag Predicate ``compare-latest``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+::
+
+   (compare-latest PACKAGE [OP VERSION])
+
+If ``OP`` and ``VERSION`` are not specified, matches tags which have
+any build of the given ``PACKAGE`` name as latest.
+
+If ``OP`` and ``VERSION`` are specified, matches tags which have the a
+latest build of the given ``PACKAGE`` name which compare correctly. If
+tag doesn't have any build of the given package, it will not match.
+
+``OP`` can be any of the following comparison operators: ``==``,
+``!=``, ``>``, ``>=``, ``<``, ``<=``
+
+``VERSION`` can be in any of the following forms:
+
+  * ``EPOCH:VERSION``
+  * ``EPOCH:VERSION-RELEASE``
+  * ``VERSION``
+  * ``VERSION-RELEASE``
+
+If ``EPOCH`` is omitted, it is presumed to be ``0``.
+If ``RELEASE`` is omitted, it is presumed to be equivalent.
+
+
 Tag Predicate ``dest-tag``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::

--- a/kojismokydingo.spec
+++ b/kojismokydingo.spec
@@ -193,6 +193,7 @@ Koji Smoky Dingo
 %{python2_sitelib}/kojismokydingo/
 %{python2_sitelib}/kojismokydingo-%{version}.dist-info/
 %{_bindir}/ksd-filter-builds
+%{_bindir}/ksd-filter-tags
 
 %doc README.md
 %license LICENSE
@@ -219,6 +220,7 @@ Koji Smoky Dingo
 %{python3_sitelib}/kojismokydingo/
 %{python3_sitelib}/kojismokydingo-%{version}.dist-info/
 %{_bindir}/ksd-filter-builds
+%{_bindir}/ksd-filter-tags
 
 %doc README.md
 %license LICENSE

--- a/kojismokydingo.spec
+++ b/kojismokydingo.spec
@@ -15,7 +15,6 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 BuildArch: noarch
 
 Source0: %{name}-%{version}.tar.gz
-Patch0: no-koji.patch
 
 
 # we don't generate binaries, let's turn that part off
@@ -67,7 +66,7 @@ Koji Smoky Dingo
 
 %prep
 %setup -q
-%patch0 -p1
+patch -p1 < no-koji.patch
 
 
 %build

--- a/kojismokydingo.spec
+++ b/kojismokydingo.spec
@@ -169,6 +169,7 @@ Koji Smoky Dingo
 %{python_sitelib}/kojismokydingo/
 %{python_sitelib}/kojismokydingo-%{version}-py2.?.egg-info/
 %{_bindir}/ksd-filter-builds
+%{_bindir}/ksd-filter-tags
 
 %endif
 
@@ -232,6 +233,8 @@ Koji Smoky Dingo
 - refactored sieve caching
 - Added 'koji open' command which will launch a browser to the info
   page for the relevant koji data type.
+- Added 'koji filter-tags' command and 'ksd-filter-tags' standalone
+  command for applying sifty predicates to filter a list of tags
 
 * Fri Dec 18 2020 Christopher O'Brien <obriencj@gmail.com> - 0.9.5-1
 - remove install_requires for koji, because koji doesn't think it's a

--- a/kojismokydingo/__init__.py
+++ b/kojismokydingo/__init__.py
@@ -37,10 +37,12 @@ __all__ = (
     "BadDingo",
     "FeatureUnavailable",
     "ManagedClientSession",
+    "NoSuchArchive",
     "NoSuchBuild",
     "NoSuchChannel",
     "NoSuchContentGenerator",
     "NoSuchPermission",
+    "NoSuchRPM",
     "NoSuchTag",
     "NoSuchTarget",
     "NoSuchTask",
@@ -48,11 +50,13 @@ __all__ = (
     "NotPermitted",
     "ProfileClientSession",
 
+    "as_archiveinfo",
     "as_buildinfo",
+    "as_hostinfo",
+    "as_rpminfo",
     "as_taginfo",
     "as_targetinfo",
     "as_taskinfo",
-    "as_hostinfo",
     "as_userinfo",
     "bulk_load",
     "bulk_load_build_archives",
@@ -209,6 +213,22 @@ class NoSuchPermission(BadDingo):
     """
 
     complaint = "No such permission"
+
+
+class NoSuchArchive(BadDingo):
+    """
+    An archive was not found
+    """
+
+    complaint = "No such archive"
+
+
+class NoSuchRPM(BadDingo):
+    """
+    An RPM was not found
+    """
+
+    complaint = "No such RPM"
 
 
 class NotPermitted(BadDingo):
@@ -719,6 +739,76 @@ def as_hostinfo(session, host):
 
     if not info:
         raise NoSuchHost(host)
+
+    return info
+
+
+def as_archiveinfo(session, archive):
+    """
+    Coerces an archive value into an archive info dict.
+
+    If archive is an:
+     * int, will attempt to load as an archive ID
+     * str, will attempt to load as an archive filename
+     * dict, will presume already an archive info
+
+    :param archive: value to lookup
+
+    :type archive: int or str or dict
+
+    :raises NoSuchArchive: if the archive value could not be resolved
+      into an archive info dict
+
+    :rtype dict:
+    """
+
+    if isinstance(archive, int):
+        info = session.getArchive(archive)
+
+    elif isinstance(archive, str):
+        found = session.listArchives(filename=archive)
+        info = found[0] if found else None
+
+    elif isinstance(archive, dict):
+        info = archive
+
+    else:
+        info = None
+
+    if not info:
+        raise NoSuchArchive(archive)
+
+    return info
+
+
+def as_rpminfo(session, rpm):
+    """
+    Coerces a host value into a RPM info dict.
+
+    If rpm is an:
+     * int, will attempt to load as a RPM ID
+     * str, will attempt to load as a RPM NVR
+     * dict, will presume already an RPM info
+
+    :param rpm: value to lookup
+
+    :type rpm: int or str or dict
+
+    :raises NoSuchRPM: if the rpm value could not be resolved
+      into a RPM info dict
+
+    :rtype: dict
+    """
+
+    if isinstance(rpm, (str, int)):
+        info = session.getRPM(rpm)
+    elif isinstance(rpm, dict):
+        info = rpm
+    else:
+        info = None
+
+    if not info:
+        raise NoSuchRPM(rpm)
 
     return info
 

--- a/kojismokydingo/cli/clients.py
+++ b/kojismokydingo/cli/clients.py
@@ -30,8 +30,8 @@ from six.moves.configparser import ConfigParser
 
 from . import AnonSmokyDingo, BadDingo, int_or_str, pretty_json
 from .. import (
-    as_buildinfo, as_taginfo, as_targetinfo, as_hostinfo,
-    as_taskinfo, as_userinfo, )
+    as_archiveinfo, as_buildinfo, as_hostinfo, as_rpminfo,
+    as_taginfo, as_targetinfo, as_taskinfo, as_userinfo, )
 from ..clients import rebuild_client_config
 
 
@@ -112,29 +112,33 @@ class ClientConfig(AnonSmokyDingo):
 
 
 OPEN_LOADFN = {
+    "archive": as_archiveinfo,
     "build": as_buildinfo,
+    "host": as_hostinfo,
+    "rpm": as_rpminfo,
     "tag": as_taginfo,
     "target": as_targetinfo,
-    "user": as_userinfo,
-    "host": as_hostinfo,
     "task": as_taskinfo,
+    "user": as_userinfo,
 }
 
 
 OPEN_CMD = {
-    "linux": "xdg-open",
     "darwin": "open",
+    "linux": "xdg-open",
     "win32": "start",
 }
 
 
 OPEN_URL = {
+    "archive": "archiveinfo?archiveID={id}",
     "build": "buildinfo?buildID={id}",
+    "host": "hostinfo?hostID={id}",
+    "rpm": "rpminfo?rpmID={id}",
     "tag": "taginfo?tagID={id}",
     "target": "buildtargetinfo?targetID={id}",
-    "user": "userinfo?userID={id}",
-    "host": "hostinfo?hostID={id}",
     "task": "taskinfo?taskID={id}",
+    "user": "userinfo?userID={id}",
 }
 
 

--- a/kojismokydingo/cli/sift.py
+++ b/kojismokydingo/cli/sift.py
@@ -33,11 +33,13 @@ from . import open_output, resplit
 from ..common import escapable_replace
 from ..sift import DEFAULT_SIEVES, Sifter, SifterError
 from ..sift.builds import build_info_sieves
+from ..sift.tags import tag_info_sieves
 
 
 __all__ = (
     "BuildSifting",
     "Sifting",
+    "TagSifting",
 
     "output_sifted",
 )
@@ -190,6 +192,12 @@ class BuildSifting(Sifting):
 
     def get_sieves(self):
         return build_info_sieves()
+
+
+class TagSifting(Sifting):
+
+    def get_sieves(self):
+        return tag_info_sieves()
 
 
 def output_sifted(results, key="id", outputs=None, sort=None):

--- a/kojismokydingo/sift/__init__.py
+++ b/kojismokydingo/sift/__init__.py
@@ -50,15 +50,18 @@ __all__ = (
 
     "Flagged",
     "Flagger",
+    "IntStrSieve",
     "ItemPathSieve",
     "ItemSieve",
     "Logic",
     "LogicAnd",
     "LogicNot",
     "LogicOr",
+    "MatcherSieve",
     "Sieve",
     "Sifter",
     "SifterError",
+    "SymbolSieve",
     "VariadicSieve",
 
     "ensure_all_int_or_str",
@@ -631,6 +634,39 @@ class Sieve(object):
         """
 
         return self.sifter.get_info_cache(self.name, info)
+
+
+class MatcherSieve(Sieve):
+    """
+    A Sieve that requires all of its arguments to be matchers. Calls
+    `ensure_all_matcher` on `tokens`
+    """
+
+    def __init__(self, sifter, *tokens):
+        tokens = ensure_all_matcher(tokens)
+        super(MatcherSieve, self).__init__(sifter, *tokens)
+
+
+class SymbolSieve(Sieve):
+    """
+    A Sieve that requires all of its arguments to be matchers. Calls
+    `ensure_all_symbol` on `tokens`
+    """
+
+    def __init__(self, sifter, *tokens):
+        tokens = ensure_all_symbol(tokens)
+        super(SymbolSieve, self).__init__(sifter, *tokens)
+
+
+class IntStrSieve(Sieve):
+    """
+    A Sieve that requires all of its arguments to be matchers. Calls
+    `ensure_all_int_or_str` on `tokens`
+    """
+
+    def __init__(self, sifter, *tokens):
+        tokens = ensure_all_int_or_str(tokens)
+        super(IntStrSieve, self).__init__(sifter, *tokens)
 
 
 @add_metaclass(ABCMeta)

--- a/kojismokydingo/sift/__init__.py
+++ b/kojismokydingo/sift/__init__.py
@@ -293,7 +293,14 @@ class Sifter(object):
         self._cache = {}
 
         if not isinstance(sieves, dict):
-            sieves = dict((sieve.name, sieve) for sieve in sieves)
+            # convert a list of sieves into a dict mapping the sieve
+            # names and their aliases to the classes
+            sieves = tuple(sieves)
+            sievedict = dict((sieve.name, sieve) for sieve in sieves)
+            for sieve in sieves:
+                for alias in sieve.aliases:
+                    sievedict[alias] = sieve
+            sieves = sievedict
 
         self._sieve_classes = sieves
 
@@ -544,6 +551,9 @@ class Sieve(object):
     @abstractproperty
     def name(self):
         pass
+
+
+    aliases = ()
 
 
     def __init__(self, sifter, *tokens):

--- a/kojismokydingo/sift/__init__.py
+++ b/kojismokydingo/sift/__init__.py
@@ -41,7 +41,7 @@ from six.moves import map
 
 from .. import BadDingo
 from .parse import (
-    Glob, Regex, Symbol, Matcher, ItemPath, Number,
+    Glob, ItemPath, Matcher, Number, Regex, Symbol, SymbolGroup,
     convert_token, parse_exprs, )
 
 
@@ -99,17 +99,36 @@ def ensure_symbol(value, msg=None):
                       (msg, value, type(value).__name__))
 
 
-def ensure_all_symbol(values, msg=None):
+def ensure_all_symbol(values, expand=True, msg=None):
     """
     Checks that all of the elements in values are Symbols, and returns
     them as a new list.  If not, raises a SifterError.
+
+    If expand is True then any SymbolGroup instances will be expanded
+    to their full combination of Symbols and inlined. Otherwise, the
+    inclusion of a SymbolGroup is an error.
 
     :type values: list
 
     :rtype: list[Symbol]
     """
 
-    return [ensure_symbol(val, msg) for val in values]
+    result = []
+
+    for val in values:
+        if isinstance(val, Symbol):
+            result.append(val)
+
+        elif expand and isinstance(val, SymbolGroup):
+            result.extend(val)
+
+        else:
+            if not msg:
+                msg = "Value must be a symbol"
+            raise SifterError("%s: %r (type %s)" %
+                              (msg, val, type(val).__name__))
+
+    return result
 
 
 def ensure_str(value, msg=None):

--- a/kojismokydingo/sift/builds.py
+++ b/kojismokydingo/sift/builds.py
@@ -36,7 +36,7 @@ from . import (
     IntStrSieve, ItemSieve, MatcherSieve, Sieve,
     Sifter, SifterError, VariadicSieve,
     ensure_int_or_str, ensure_str, ensure_symbol, )
-from .common import CacheMixin
+from .common import ensure_comparison, CacheMixin
 from .. import (
     as_taginfo, bulk_load_builds, bulk_load_tags, bulk_load_users,
     iter_bulk_load, )
@@ -83,27 +83,6 @@ __all__ = (
     "sift_builds",
     "sift_nvrs",
 )
-
-
-_OPMAP = {
-    "==": operator.eq,
-    "!=": operator.ne,
-    ">": operator.gt,
-    ">=": operator.ge,
-    "<": operator.lt,
-    "<=": operator.le,
-}
-
-
-def ensure_comparison(value):
-    value = ensure_symbol(value)
-
-    if value in _OPMAP:
-        return _OPMAP[value]
-
-    else:
-        msg = "Invalid comparison operator: %r" % value
-        raise SifterError(msg)
 
 
 class NVRSieve(ItemSieve):
@@ -266,7 +245,7 @@ class EVRCompare(Sieve):
         self.version = version
         self.release = release
 
-        self.op = _OPMAP[self.name]
+        self.op = ensure_comparison(self.name)
 
 
     def check(self, session, binfo):

--- a/kojismokydingo/sift/builds.py
+++ b/kojismokydingo/sift/builds.py
@@ -35,7 +35,6 @@ from . import (
     DEFAULT_SIEVES,
     IntStrSieve, ItemSieve, MatcherSieve, Sieve,
     Sifter, SifterError, VariadicSieve,
-    ensure_all_matcher, ensure_all_int_or_str,
     ensure_int_or_str, ensure_str, ensure_symbol, )
 from .common import CacheMixin
 from .. import (

--- a/kojismokydingo/sift/builds.py
+++ b/kojismokydingo/sift/builds.py
@@ -70,7 +70,7 @@ __all__ = (
     "OwnerSieve",
     "PkgAllowedSieve",
     "PkgBlockedSieve",
-    "PkgListSieve",
+    "PkgUnlistedSieve",
     "ReleaseSieve",
     "SignedSieve",
     "StateSieve",
@@ -545,6 +545,30 @@ class PkgBlockedSieve(PkgListSieve):
             return False
 
 
+class PkgUnlistedSieve(PkgListSieve):
+    """
+    usage: ``(pkg-unlisted TAG [TAG...])``
+
+    Matches builds which have their package name unlisted (neither
+    allowed nor blocked) in any of the given tags or their parents.
+    """
+
+    name = "pkg-unlisted"
+
+    def check(self, session, binfo):
+        pkg = binfo["name"]
+
+        for tid in self.tag_ids:
+            if pkg in self.allowed_packages(session, tid, True):
+                continue
+            elif pkg in self.blocked_packages(session, tid, True):
+                continue
+            else:
+                return True
+        else:
+            return False
+
+
 class TypeSieve(MatcherSieve):
     """
     usage: ``(type BTYPE [BTYPE...])``
@@ -877,6 +901,7 @@ DEFAULT_BUILD_INFO_SIEVES = [
     OwnerSieve,
     PkgAllowedSieve,
     PkgBlockedSieve,
+    PkgUnlistedSieve,
     ReleaseSieve,
     SignedSieve,
     StateSieve,

--- a/kojismokydingo/sift/builds.py
+++ b/kojismokydingo/sift/builds.py
@@ -33,7 +33,8 @@ from six.moves import filter
 
 from . import (
     DEFAULT_SIEVES,
-    ItemSieve, Sieve, Sifter, SifterError, VariadicSieve,
+    IntStrSieve, ItemSieve, MatcherSieve, Sieve,
+    Sifter, SifterError, VariadicSieve,
     ensure_all_matcher, ensure_all_int_or_str,
     ensure_int_or_str, ensure_str, ensure_symbol, )
 from .common import CacheMixin
@@ -192,7 +193,7 @@ class StateSieve(ItemSieve):
         super(ItemSieve, self).__init__(sifter, state)
 
 
-class OwnerSieve(Sieve):
+class OwnerSieve(IntStrSieve):
     """
     Usage: ``(owner USER [USER...])```
 
@@ -207,11 +208,7 @@ class OwnerSieve(Sieve):
 
 
     def __init__(self, sifter, user, *users):
-        usernames = [user]
-        usernames.extend(users)
-        usernames = ensure_all_int_or_str(usernames)
-
-        super(OwnerSieve, self).__init__(sifter, *usernames)
+        super(OwnerSieve, self).__init__(sifter, user, *users)
         self._user_ids = None
 
 
@@ -409,7 +406,7 @@ class EVRCompareLE(EVRCompare):
     name = "<="
 
 
-class TaggedSieve(Sieve):
+class TaggedSieve(MatcherSieve):
     """
     usage: (tagged [TAG...])
 
@@ -421,11 +418,6 @@ class TaggedSieve(Sieve):
     """
 
     name = "tagged"
-
-
-    def __init__(self, sifter, *tagnames):
-        tagnames = ensure_all_matcher(tagnames)
-        super(TaggedSieve, self).__init__(sifter, *tagnames)
 
 
     def prep(self, session, binfos):
@@ -464,7 +456,7 @@ class TaggedSieve(Sieve):
         return False
 
 
-class InheritedSieve(Sieve):
+class InheritedSieve(IntStrSieve):
     """
     usage: (inherited TAG [TAG...])
 
@@ -477,11 +469,7 @@ class InheritedSieve(Sieve):
 
 
     def __init__(self, sifter, tagname, *tagnames):
-        tags = [tagname]
-        tags.extend(tagnames)
-        tags = ensure_all_int_or_str(tags)
-
-        super(InheritedSieve, self).__init__(sifter, *tags)
+        super(InheritedSieve, self).__init__(sifter, tagname, *tagnames)
         self.tag_ids = None
 
 
@@ -519,15 +507,10 @@ class InheritedSieve(Sieve):
         return False
 
 
-class PkgListSieve(CacheMixin):
+class PkgListSieve(IntStrSieve, CacheMixin):
 
     def __init__(self, sifter, tagname, *tagnames):
-        tags = [tagname]
-        tags.extend(tagnames)
-        tags = ensure_all_int_or_str(tags)
-
-        super(PkgListSieve, self).__init__(sifter, *tags)
-
+        super(PkgListSieve, self).__init__(sifter, tagname, *tagnames)
         self.tag_ids = None
 
 
@@ -585,7 +568,7 @@ class PkgBlockedSieve(PkgListSieve):
             return False
 
 
-class TypeSieve(Sieve):
+class TypeSieve(MatcherSieve):
     """
     usage: ``(type BTYPE [BTYPE...])``
 
@@ -597,11 +580,7 @@ class TypeSieve(Sieve):
 
 
     def __init__(self, sifter, btype, *btypes):
-        bts = [btype]
-        bts.extend(btypes)
-        bts = ensure_all_matcher(bts)
-
-        super(TypeSieve, self).__init__(sifter, *bts)
+        super(TypeSieve, self).__init__(sifter, btype, *btypes)
 
 
     def prep(self, session, binfos):
@@ -618,7 +597,7 @@ class TypeSieve(Sieve):
         return False
 
 
-class CGImportedSieve(Sieve):
+class CGImportedSieve(MatcherSieve):
     """
     usage: ``(cg-imported [CGNAME...])``
 
@@ -628,11 +607,6 @@ class CGImportedSieve(Sieve):
     """
 
     name = "cg-imported"
-
-
-    def __init__(self, sifter, *cgnames):
-        cgnames = ensure_all_matcher(cgnames)
-        super(CGImportedSieve, self).__init__(sifter, *cgnames)
 
 
     def prep(self, session, binfos):
@@ -654,7 +628,7 @@ class CGImportedSieve(Sieve):
             return bool(cg_names)
 
 
-class LatestSieve(CacheMixin):
+class LatestSieve(IntStrSieve, CacheMixin):
     """
     usage: ``(latest TAG [TAG...])``
 
@@ -666,11 +640,7 @@ class LatestSieve(CacheMixin):
 
 
     def __init__(self, sifter, tagname, *tagnames):
-        tags = [tagname]
-        tags.extend(tagnames)
-        tags = ensure_all_int_or_str(tags)
-
-        super(LatestSieve, self).__init__(sifter, *tags)
+        super(LatestSieve, self).__init__(sifter, tagname, *tagnames)
         self.tag_ids = None
 
 
@@ -696,7 +666,7 @@ class LatestSieve(CacheMixin):
         return False
 
 
-class LatestMavenSieve(CacheMixin):
+class LatestMavenSieve(IntStrSieve, CacheMixin):
     """
     usage: ``(latest-maven TAG [TAG...])``
 
@@ -708,11 +678,7 @@ class LatestMavenSieve(CacheMixin):
 
 
     def __init__(self, sifter, tagname, *tagnames):
-        tags = [tagname]
-        tags.extend(tagnames)
-        tags = ensure_all_int_or_str(tags)
-
-        super(LatestMavenSieve, self).__init__(sifter, *tags)
+        super(LatestMavenSieve, self).__init__(sifter, tagname, *tagnames)
         self.tag_ids = None
 
 
@@ -746,7 +712,7 @@ class LatestMavenSieve(CacheMixin):
         return False
 
 
-class SignedSieve(Sieve):
+class SignedSieve(MatcherSieve):
     """
     usage: ``(signed [KEY...])``
 
@@ -756,12 +722,6 @@ class SignedSieve(Sieve):
     """
 
     name = "signed"
-
-
-    def __init__(self, sifter, *keys):
-        keys = ensure_all_matcher(keys)
-        super(SignedSieve, self).__init__(sifter, *keys)
-        self.keys = keys or None
 
 
     def prep(self, session, binfos):
@@ -782,13 +742,15 @@ class SignedSieve(Sieve):
 
 
     def check(self, session, binfo):
-        want_keys = self.keys
+        want_keys = self.tokens
         build_keys = self.get_info_cache(binfo).get("rpmsigs")
 
-        if want_keys is None:
+        if not want_keys:
             return bool(build_keys)
+
         elif build_keys is None:
             return False
+
         else:
             for wanted in want_keys:
                 if wanted in build_keys:

--- a/kojismokydingo/sift/builds.py
+++ b/kojismokydingo/sift/builds.py
@@ -427,12 +427,11 @@ class TaggedSieve(MatcherSieve):
             if "tag_names" not in cache:
                 needed[binfo["id"]] = cache
 
-        if needed:
-            fn = lambda i: session.listTags(build=i)
-            for bid, tags in iter_bulk_load(session, fn, needed):
-                cache = needed[bid]
-                cache["tag_names"] = [t["name"] for t in tags]
-                cache["tag_ids"] = [t["id"] for t in tags]
+        fn = lambda i: session.listTags(build=i)
+        for bid, tags in iter_bulk_load(session, fn, needed):
+            cache = needed[bid]
+            cache["tag_names"] = [t["name"] for t in tags]
+            cache["tag_ids"] = [t["id"] for t in tags]
 
 
     def check(self, session, binfo):

--- a/kojismokydingo/sift/common.py
+++ b/kojismokydingo/sift/common.py
@@ -27,6 +27,7 @@ from operator import itemgetter
 from six.moves import map
 
 from . import SifterError, Sieve
+from .. import iter_bulk_load
 from ..builds import latest_maven_builds
 
 
@@ -172,6 +173,34 @@ class CacheMixin(Sieve):
         return found
 
 
+    def bulk_list_packages(self, session, tag_ids, inherited=True):
+        """
+        a multicall caching wrapper for session.listPackages
+
+        shares the same cache as `list_packages` (and therefore
+        `allowed_packages` and `blocked_packages`)
+
+        :rtype: dict[int,list[dict]]
+        """
+
+        cache = self._mixing_cache("list_packages")
+
+        result = {}
+        needed = []
+
+        for tid in tag_ids:
+            if (tid, inherited) not in cache:
+                needed.append(tid)
+            else:
+                result[tid] = cache
+
+        fn = lambda i: session.listPackages(i, inherited=inherited)
+        for tid, pkgs in iter_bulk_load(session, fn, needed):
+            result[tid] = cache[(tid, inherited)] = pkgs
+
+        return result
+
+
     def list_packages(self, session, tag_id, inherited=True):
         """
         a caching wrapper for session.listPackages
@@ -185,7 +214,8 @@ class CacheMixin(Sieve):
         found = cache.get(key)
 
         if found is None:
-            found = cache[key] = session.listPackages(tag_id, inherited=True)
+            found = cache[key] = session.listPackages(tag_id,
+                                                      inherited=inherited)
 
         return found
 
@@ -234,6 +264,48 @@ class CacheMixin(Sieve):
                     found.add(pkg["package_name"])
 
         return found
+
+
+    def get_tag_groups(self, session, tag_id):
+        """
+        a caching wrapper for session.getTagGroups
+
+        :rtype: list[dict]
+        """
+
+        cache = self._mixin_cache("groups")
+
+        found = cache.get(tag_id)
+        if found is None:
+            found = cache[tag_id] = session.getTagGroups(tag_id)
+
+        return found
+
+
+    def bulk_get_tag_groups(self, session, tag_ids):
+        """
+        a multicall caching wrapper for session.getTagGroups. Shares a
+        cache with `get_tag_groups`
+
+        :rtype: dict[int, list[dict]]
+        """
+
+        cache = self._mixin_cache("groups")
+
+        result = {}
+        needed = []
+
+        for tid in tag_ids:
+            if tid in cache:
+                result[tid] = cache[tid]
+            else:
+                needed.append(tid)
+
+        fn = session.getTagGroups
+        for tid, found in iter_bulk_load(session, fn, needed):
+            result[tid] = cache[tid] = found
+
+        return result
 
 
 # The end.

--- a/kojismokydingo/sift/common.py
+++ b/kojismokydingo/sift/common.py
@@ -21,14 +21,46 @@ Sieves
 """
 
 
+import operator
+
 from operator import itemgetter
 from six.moves import map
 
-from . import Sieve
+from . import SifterError, Sieve
 from ..builds import latest_maven_builds
 
 
-__all__ = ("CacheMixin", )
+__all__ = ("CacheMixin", "ensure_comparison", )
+
+
+_OPMAP = {
+    "==": operator.eq,
+    "!=": operator.ne,
+    ">": operator.gt,
+    ">=": operator.ge,
+    "<": operator.lt,
+    "<=": operator.le,
+}
+
+
+def ensure_comparison(value):
+    """
+    Converts a comparison operator symbol into a comparison function.
+
+    :param value: The symbol or string to convert. Should be one of
+      '==', '!=', '>', '>=', '<', '<='
+
+    :type value: str
+
+    :rtype: callable
+    """
+
+    if value in _OPMAP:
+        return _OPMAP[value]
+
+    else:
+        msg = "Invalid comparison operator: %r" % value
+        raise SifterError(msg)
 
 
 class CacheMixin(Sieve):

--- a/kojismokydingo/sift/parse.py
+++ b/kojismokydingo/sift/parse.py
@@ -402,7 +402,7 @@ def convert_group(grp):
 
     work = []
     for brk in grp.split(","):
-        if work and _trailing_esc(work[-1][-1]) & 1:
+        if work and work[-1] and _trailing_esc(work[-1][-1]) & 1:
             work[-1] = ",".join((work[-1][:-1], brk))
         else:
             work.append(brk)

--- a/kojismokydingo/sift/parse.py
+++ b/kojismokydingo/sift/parse.py
@@ -297,6 +297,11 @@ class AllItems(Item):
 
 class ItemPath(object):
 
+    @staticmethod
+    def from_str(src):
+        return parse_itempath(src)
+
+
     def __init__(self, *paths):
         self.paths = list(paths)
 

--- a/kojismokydingo/sift/parse.py
+++ b/kojismokydingo/sift/parse.py
@@ -296,11 +296,10 @@ class AllItems(Item):
 
 
 class ItemPath(object):
-
-    @staticmethod
-    def from_str(src):
-        return parse_itempath(src)
-
+    """
+    Represents a collection of elements inside a nested tree of lists
+    and dicts
+    """
 
     def __init__(self, *paths):
         self.paths = list(paths)
@@ -589,7 +588,7 @@ def convert_token(val):
                 # in cases where there's only one choice in all the
                 # groups, then we can simply create a single Symbol
                 # from those merged choices.
-                val = "".join(g[0] for g in grps)
+                val = "".join(str(g[0]) for g in grps)
                 return Symbol(val)
             else:
                 return SymbolGroup(val, grps)

--- a/kojismokydingo/sift/tags.py
+++ b/kojismokydingo/sift/tags.py
@@ -321,7 +321,7 @@ class HasParentSieve(InheritanceSieve):
     aliases = ["child-of", ]
 
 
-    def getParents(self, session, tagids):
+    def getInheritance(self, session, tagids):
         return iter_bulk_load(session, session.getInheritanceData, tagids)
 
 
@@ -342,7 +342,7 @@ class HasAncestorSieve(InheritanceSieve):
     aliases = ["inherits-from", ]
 
 
-    def getParents(self, session, tagids):
+    def getInheritance(self, session, tagids):
         return iter_bulk_load(session, session.getFullInheritance, tagids)
 
 
@@ -363,7 +363,7 @@ class HasChildSieve(InheritanceSieve):
     aliases = ["parent-of", ]
 
 
-    def getParents(self, session, tagids):
+    def getInheritance(self, session, tagids):
         fn = lambda i: session.getFullInheritance(i, reverse=True)
         for tid, inher in iter_bulk_load(session, fn, tagids):
             yield tid, [p for p in inher if p["currdepth"] == 1]
@@ -386,7 +386,7 @@ class HasDescendantSieve(InheritanceSieve):
     aliases = ["inherited-by", ]
 
 
-    def getParents(self, session, tagids):
+    def getInheritance(self, session, tagids):
         fn = lambda i: session.getFullInheritance(i, reverse=True)
         return iter_bulk_load(session, fn, tagids)
 

--- a/kojismokydingo/sift/tags.py
+++ b/kojismokydingo/sift/tags.py
@@ -27,8 +27,7 @@ from six import iteritems, itervalues
 
 from . import (
     DEFAULT_SIEVES,
-    ItemSieve, MatcherSieve, Sieve, Sifter, SymbolSieve,
-    ensure_all_matcher, ensure_all_symbol, )
+    ItemSieve, MatcherSieve, Sieve, Sifter, SymbolSieve, )
 from .. import (
     bulk_load_tags, )
 from ..tags import (

--- a/kojismokydingo/sift/tags.py
+++ b/kojismokydingo/sift/tags.py
@@ -1,0 +1,215 @@
+# This library is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses/>.
+
+
+"""
+Koji Smoky Dingo - Sifty Dingo filtering for Koji Tags
+
+This module provides sieves for filtering through koji tag info
+dicts.
+
+:author: Christopher O'Brien <obriencj@gmail.com>
+:license: GPL v3
+"""
+
+
+from six import iteritems, itervalues
+
+from . import (
+    DEFAULT_SIEVES,
+    ItemSieve, Sieve, Sifter,
+    ensure_all_matcher, ensure_all_symbol, )
+from .. import (
+    bulk_load_tags, )
+from ..tags import (
+    gather_tag_ids, tag_dedup, )
+
+
+__all__ = (
+    "DEFAULT_TAG_INFO_SIEVES",
+
+    "tag_info_sieves",
+    "tag_info_sifter",
+    "sift_tags",
+    "sift_tagnames",
+)
+
+
+class NameSieve(ItemSieve):
+    """
+    Usage: ``(name NAME [NAME...])``
+
+    filters for dict infos whose `name` key matches any of the given
+    NAME matchers.
+    """
+
+    name = field = "name"
+
+
+class ArchSieve(Sieve):
+    """
+    usage: ``(arch [ARCH...])``
+
+    If no ARCH patterns are specified, matches tags which have any
+    architectures at all.
+
+    If ARCH patterns are specified, then only matches tags which have
+    an architecture that matches any of the given patterns.
+    """
+
+    name = "arch"
+
+
+    def __init__(self, sifter, *arches):
+        arches = ensure_all_matcher(arches)
+        super(ArchSieve, self).__init__(sifter, *arches)
+
+
+    def prep(self, session, taginfos):
+        for tag in taginfos:
+            cache = self.get_info_cache(tag)
+            if "arches" not in cache:
+                tagarch = tag["arches"]
+                cache["arches"] = tagarch.split() if tagarch else ()
+
+
+    def check(self, session, taginfo):
+        wanted = self.tokens
+
+        if not wanted:
+            return bool(taginfo["arches"])
+
+        cache = self.get_info_cache(taginfo)
+        arches = cache.get("arches", ())
+
+        for tok in wanted:
+            if tok in arches:
+                return True
+
+        return False
+
+
+class ExactArchSieve(ArchSieve):
+    """
+    usage: ``(exact-arch [ARCH...])``
+
+    If no ARCH names are specified, matches only tags which have no
+    architectures.
+
+    If ARCH names are specified, they must be specified as symbols.
+    Only matches tags which have the exact same set of architectures.
+    """
+
+    name = "exact-arch"
+
+
+    def __init__(self, sifter, *arches):
+        arches = ensure_all_symbol(arches)
+        super(ExactArchSieve, self).__init__(sifter, *arches)
+
+
+    def get_info_cache(self, tinfo):
+        # let's use the same caches that the ArchSieve uses
+        return self.sifter.get_info_cache("arch", tinfo)
+
+
+    def check(self, session, taginfo):
+        wanted = self.tokens
+
+        if not wanted:
+            return not taginfo["arches"]
+
+        cache = self.get_info_cache(taginfo)
+        arches = cache.get("arches", ())
+
+        if len(arches) != len(wanted):
+            return False
+
+        for tok in wanted:
+            if tok not in arches:
+                return False
+
+        return True
+
+
+DEFAULT_TAG_INFO_SIEVES = [
+    ArchSieve,
+    ExactArchSieve,
+    NameSieve,
+]
+
+
+def tag_info_sieves():
+    """
+    A new list containing the default tag-info sieve classes.
+
+    This function is used by `tag_info_sifter` when creating its
+    `Sifter` instance.
+
+    :rtype: list[type[Sieve]]
+    """
+
+    sieves = []
+    sieves.extend(DEFAULT_SIEVES)
+    sieves.extend(DEFAULT_TAG_INFO_SIEVES)
+
+    return sieves
+
+
+def tag_info_sifter(source, params=None):
+    """
+    Create a Sifter from the source using the default tag-info
+    Sieves.
+
+    :param source: sieve expressions source
+    :type source: stream or str
+
+    :rtype: Sifter
+    """
+
+    return Sifter(tag_info_sieves(), source, "id", params)
+
+
+def sift_tags(session, src_str, tag_infos, params=None):
+    """
+    :param src_str: sieve expressions source
+    :type src_str: src
+
+    :param build_infos: list of tag info dicts to filter
+    :type build_infos: list[dict]
+
+    :rtype: dict[str,list[dict]]
+    """
+
+    sifter = tag_info_sifter(src_str, params)
+    return sifter(session, tag_infos)
+
+
+def sift_tagnames(session, src_str, names, params=None):
+    """
+    :param src_str: sieve expressions source
+    :type src_str: src
+
+    :param nvrs: list of tag names to load and filter
+    :type nvrs: list[str]
+
+    :rtype: dict[str,list[dict]]
+    """
+
+    loaded = bulk_load_tags(session, names, err=False)
+    tags = tag_dedup(itervalues(loaded))
+    return sift_tags(session, src_str, tags, params)
+
+
+#
+# The end.

--- a/kojismokydingo/standalone/builds.py
+++ b/kojismokydingo/standalone/builds.py
@@ -13,10 +13,7 @@
 
 
 """
-Koji Smoky Dingo - Standalone
-
-This package contains adaptive mechanisms for converting a SmokyDingo command
-into a stand-alone console_script entry point.
+Koji Smoky Dingo - Standalone build commands
 
 :author: Christopher O'Brien <obriencj@gmail.com>
 :licence: GPL v3
@@ -41,8 +38,7 @@ class LonelyFilterBuilds(AnonLonelyDingo, FilterBuilds):
     Adapter to make the FilterBuilds command into a LonelyDingo.
     """
 
-
-    def __init__(self, name):
+    def __init__(self, name=None):
         super(LonelyFilterBuilds, self).__init__(name)
 
         # some trickery to un-require the --profile option, though we

--- a/kojismokydingo/standalone/tags.py
+++ b/kojismokydingo/standalone/tags.py
@@ -1,0 +1,126 @@
+# This library is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses/>.
+
+
+"""
+Koji Smoky Dingo - Standalone tag commands
+
+:author: Christopher O'Brien <obriencj@gmail.com>
+:licence: GPL v3
+"""
+
+
+from six import iteritems
+
+from . import AnonLonelyDingo
+from ..cli import find_action, printerr, remove_action, resplit
+from ..cli.tags import FilterTags
+
+
+__all__ = (
+    "LonelyFilterTags",
+    "ksd_filter_tags",
+)
+
+
+class LonelyFilterTags(AnonLonelyDingo, FilterTags):
+    """
+    Adapter to make the FilterTags command into a LonelyDingo.
+    """
+
+    def __init__(self, name=None):
+        super(LonelyFilterTags, self).__init__(name)
+
+        # some trickery to un-require the --profile option, though we
+        # will mimic the behavior later. We need to do this because
+        # this standalone may pull a profile out of the filter file
+        # itself. We'll make sure to fail empty profile values later
+        # in validation.
+        self.default_profile = ""
+
+
+    def arguments(self, parser):
+        addarg = parser.add_argument
+        addarg("filter_file", metavar="FILTER_FILE",
+               help="File of sifty filter predicates")
+
+        return super(LonelyFilterTags, self).arguments(parser)
+
+
+    def sifter_arguments(self, parser):
+        parser = super(LonelyFilterTags, self).sifter_arguments(parser)
+        remove_action(parser, "--filter")
+        remove_action(parser, "--filter-file")
+        return parser
+
+
+    def validate(self, parser, options):
+        # we need to go through the filter_file to look for the define
+        # directives, which is not part of the normal sifty filtering
+        # language. Since we're doing so, we may as well just load the
+        # filter into memory and use it for the sifter parsing as well,
+        # so we'll set filter_file to None and filter to the contents.
+
+        with open(options.filter_file, "rt") as fin:
+            src = fin.read()
+
+        options.filter_file = None
+        options.filter = src
+
+        # some options can be specified multiple times, so don't use a
+        # dict
+        defaults = []
+        params = []
+        for line in src.splitlines():
+            if line.startswith("#option "):
+                defn = line[8:].split("=", 1)
+                key = defn[0].strip()
+                val = "" if len(defn) == 1 else defn[1].strip()
+                defaults.append((key, val))
+
+            elif line.startswith("#param "):
+                defn = line[7:].split("=", 1)
+                key = defn[0].strip()
+                val = None if len(defn) == 1 else defn[1].srip()
+                params.append((key, val))
+
+        for key, val in defaults:
+            act = find_action(parser, key)
+            if not act:
+                printerr("WARNING: unknown option", key)
+
+            elif getattr(options, act.dest) == act.default:
+                # FIXME: this heuristic isn't very good. we're
+                # checking if the options object has what would be the
+                # default value, and presuming that means it wasn't
+                # set to anything, and therefore setting it to the
+                # value of the define in the script. However, this
+                # means one cannot use a command-line switch to
+                # override a define back to its default
+                # value. Something to fix later.
+                act(parser, options, val)
+
+        if not options.profile:
+            parser.error("the following arguments are required:"
+                         " --profile/-p")
+
+        self.default_params().update(params)
+
+        return super(LonelyFilterTags, self).validate(parser, options)
+
+
+ksd_filter_tags = LonelyFilterTags("ksd-filter-tags")
+
+
+#
+# The end.

--- a/kojismokydingo/tags.py
+++ b/kojismokydingo/tags.py
@@ -24,11 +24,13 @@ from collections import OrderedDict
 from functools import partial
 from itertools import chain
 from six import iteritems, itervalues
+from six.moves import filter
 
 from . import (
     NoSuchTag,
     as_taginfo, as_targetinfo,
-    bulk_load, bulk_load_tags)
+    bulk_load, bulk_load_tags, )
+from .common import unique
 
 
 __all__ = (
@@ -40,7 +42,24 @@ __all__ = (
     "gather_tag_ids",
     "renum_inheritance",
     "resolve_tag",
+    "tag_dedup",
 )
+
+
+def tag_dedup(tag_infos):
+    """
+    Given a sequence of tag info dictionaries, return a de-duplicated
+    list of same, with order preserved.
+
+    All None infos will be dropped.
+
+    :param tag_infos: tag infos to be de-duplicated.
+    :type tag_infos: list[dict]
+
+    :rtype: list[dict]
+    """
+
+    return unique(filter(None, tag_infos), key="id")
 
 
 def ensure_tag(session, name):

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ COMMANDS = {
     "client-config": "kojismokydingo.cli.clients:ClientConfig",
     "cginfo": "kojismokydingo.cli.users:CGInfo",
     "filter-builds": "kojismokydingo.cli.builds:FilterBuilds",
+    "filter-tags": "kojismokydingo.cli.tags:FilterTags",
     "latest-archives": "kojismokydingo.cli.archives:LatestArchives",
     "list-btypes": "kojismokydingo.cli.builds:ListBTypes",
     "list-build-archives": "kojismokydingo.cli.archives:ListBuildArchives",
@@ -73,6 +74,7 @@ COMMANDS = {
 
 CLI = {
     "ksd-filter-builds": "kojismokydingo.standalone.builds:ksd_filter_builds",
+    # "ksd-filter-tags": "kojismokydingo.standalone.tags:ksd_filter_tags",
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ COMMANDS = {
 
 CLI = {
     "ksd-filter-builds": "kojismokydingo.standalone.builds:ksd_filter_builds",
-    # "ksd-filter-tags": "kojismokydingo.standalone.tags:ksd_filter_tags",
+    "ksd-filter-tags": "kojismokydingo.standalone.tags:ksd_filter_tags",
 }
 
 

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -12,6 +12,8 @@
 # along with this library; if not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import print_function
+
 from pkg_resources import EntryPoint
 from six import iteritems
 from six.moves import StringIO

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -31,6 +31,7 @@ ENTRY_POINTS = {
     "check-hosts": "kojismokydingo.cli.hosts:CheckHosts",
     "client-config": "kojismokydingo.cli.clients:ClientConfig",
     "filter-builds": "kojismokydingo.cli.builds:FilterBuilds",
+    "filter-tags": "kojismokydingo.cli.tags:FilterTags",
     "latest-archives": "kojismokydingo.cli.archives:LatestArchives",
     "list-btypes": "kojismokydingo.cli.builds:ListBTypes",
     "list-build-archives": "kojismokydingo.cli.archives:ListBuildArchives",

--- a/tests/packaging.sh
+++ b/tests/packaging.sh
@@ -21,8 +21,8 @@ function expected_entry_points() {
     local PYTHON=$(whichever python3 python python2)
     read -r -d'\0' SCRIPT <<EOF
 from __future__ import print_function
-import tests.cli
-for name in sorted(tests.cli.ENTRY_POINTS):
+from tests.cli import ENTRY_POINTS
+for name in sorted(ENTRY_POINTS):
     print(name)
 EOF
     "$PYTHON" -B -c "$SCRIPT"

--- a/tests/packaging.sh
+++ b/tests/packaging.sh
@@ -17,6 +17,18 @@ function whichever() {
 }
 
 
+function expected_entry_points() {
+    local PYTHON=$(whichever python3 python python2)
+    read -r -d'\0' SCRIPT <<EOF
+from __future__ import print_function
+import tests.cli
+for name in sorted(tests.cli.ENTRY_POINTS):
+    print(name)
+EOF
+    "$PYTHON" -B -c "$SCRIPT"
+}
+
+
 function run_nose() {
     echo "Running unit tests:"
     local NOSE=$(whichever nosetests-3 nosetests nosetests-2)
@@ -40,38 +52,9 @@ function verify_koji_cli() {
     echo 'Checking output of koji help:'
 
     local HELP=$(koji help)
-    local EXPECTED=(
-        affected-targets
-        block-env-var
-        block-rpm-macro
-        bulk-tag-builds
-        cginfo
-        check-hosts
-        client-config
-        filter-builds
-        filter-tags
-        latest-archives
-        list-btypes
-        list-build-archives
-        list-cgs
-        list-component-builds
-        list-env-vars
-        list-rpm-macros
-        list-tag-extras
-        open
-        perminfo
-        remove-env-var
-        remove-rpm-macro
-        renum-tag-inheritance
-        set-env-var
-        set-rpm-macro
-        swap-tag-inheritance
-        userinfo
-    )
-
     local RESULT=0
 
-    for E in "${EXPECTED[@]}" ; do
+    for E in $(expected_entry_points) ; do
         if ! grep -F "$E" 2>/dev/null <<< "$HELP" ; then
             echo "Subcommand "$E" not present"
             RESULT=1
@@ -104,11 +87,11 @@ function ksd_rpm_tests() {
 
     {
         echo "==== BEGIN RESULTS FOR $PLATFORM ===="
-        verify_installed 2>&1
-        verify_koji_cli 2>&1
-        run_nose 2>&1
+        verify_installed
+        verify_koji_cli
+        run_nose
         echo "==== END RESULTS FOR $PLATFORM ===="
-    } | tee -a "$LOGFILE"
+    } 2>&1 | tee -a "$LOGFILE"
 
     popd >/dev/null
 }

--- a/tests/packaging.sh
+++ b/tests/packaging.sh
@@ -49,6 +49,7 @@ function verify_koji_cli() {
         check-hosts
         client-config
         filter-builds
+        filter-tags
         latest-archives
         list-btypes
         list-build-archives
@@ -57,6 +58,7 @@ function verify_koji_cli() {
         list-env-vars
         list-rpm-macros
         list-tag-extras
+        open
         perminfo
         remove-env-var
         remove-rpm-macro

--- a/tests/sift/__init__.py
+++ b/tests/sift/__init__.py
@@ -82,6 +82,9 @@ class Poke(Sieve):
 
     name = "poke"
 
+    aliases = ["incr", ]
+
+
     def __init__(self, sifter, count=-1):
         super(Poke, self).__init__(sifter)
         self._max = ensure_int(count)
@@ -846,7 +849,7 @@ class SifterTest(TestCase):
         (flag 2nd (name Draino) (poke))
         (flag 3rd (type drink) (poke 0))
         (flag keep (poke 1))
-        (!poke 2)
+        (!incr 2)
         """
         sifter = self.compile_sifter(src)
         res = sifter(None, DATA)

--- a/tests/sift/__init__.py
+++ b/tests/sift/__init__.py
@@ -19,8 +19,9 @@ from unittest import TestCase
 
 from kojismokydingo.sift import (
     DEFAULT_SIEVES,
-    Flagged, ItemPathSieve, ItemSieve, LogicAnd, LogicNot, LogicOr,
-    Sieve, Sifter, SifterError,
+    Flagged, IntStrSieve, ItemPathSieve, ItemSieve,
+    LogicAnd, LogicNot, LogicOr, MatcherSieve,
+    Sieve, Sifter, SifterError, SymbolSieve,
     ensure_all_int_or_str, ensure_all_matcher, ensure_all_symbol,
     ensure_int, ensure_int_or_str, ensure_matcher,
     ensure_str, ensure_symbol,
@@ -29,6 +30,27 @@ from kojismokydingo.sift.parse import (
     AllItems, Glob, Item, ItemMatch, ItemPath,
     Null, Number, ParserError, Regex, Symbol, SymbolGroup,
 )
+
+
+class ExIntStrSieve(IntStrSieve):
+    name = "ex-int-str"
+
+    def check(self, session, data):
+        return True
+
+
+class ExMatcherSieve(MatcherSieve):
+    name = "ex-matcher"
+
+    def check(self, session, data):
+        return True
+
+
+class ExSymbolSieve(SymbolSieve):
+    name = "ex-symbol"
+
+    def check(self, session, data):
+        return True
 
 
 class NameSieve(ItemSieve):
@@ -120,6 +142,16 @@ class SifterTest(TestCase):
         sieves.extend(DEFAULT_SIEVES)
 
         return Sifter(sieves, src, params=params)
+
+
+    def test_empty(self):
+        sifter = self.compile_sifter("")
+        sieves = sifter.sieve_exprs()
+        self.assertEqual(len(sieves), 0)
+
+        sifter = self.compile_sifter("  \n  ")
+        sieves = sifter.sieve_exprs()
+        self.assertEqual(len(sieves), 0)
 
 
     def test_int_item(self):
@@ -941,6 +973,44 @@ class EnsureTypeTest(TestCase):
 
         self.assertEqual(good_values, ensure_all_symbol(good_values))
         self.assertRaises(SifterError, ensure_all_symbol, bad_values)
+
+
+class EnsureTypeSieveTest(TestCase):
+
+
+    def test_int_or_str_sieve(self):
+        good_values = (1, Number(5), "hello", Symbol("hello"))
+
+        vals = ExIntStrSieve(Sifter((), ""), *good_values).tokens
+        self.assertEqual(good_values, vals)
+
+        bad_values = (None, Null(), Glob("*"), Regex(".*"), [], ())
+
+        self.assertRaises(SifterError, ExIntStrSieve, None, *bad_values)
+
+
+    def test_matcher_sieve(self):
+        good_values = ("hello", Null(), Number(5), Symbol("hello"),
+                       Glob("*"), Regex(".*"))
+
+        vals = ExMatcherSieve(Sifter((), ""), *good_values).tokens
+        self.assertEqual(good_values, vals)
+
+        bad_values = (None, [], (), 123)
+
+        self.assertRaises(SifterError, ExMatcherSieve, None, *bad_values)
+
+
+    def test_symbol_sieve(self):
+        good_values = (Symbol("Hello"), Symbol("World"))
+
+        vals = ExSymbolSieve(Sifter((), ""), *good_values).tokens
+        self.assertEqual(good_values, vals)
+
+        bad_values = (None, Null(), 123, Number(5), "wut",
+                      Glob("*"), Regex(".*"), [], ())
+
+        self.assertRaises(SifterError, ExSymbolSieve, None, *bad_values)
 
 
 #

--- a/tests/sift/__init__.py
+++ b/tests/sift/__init__.py
@@ -29,6 +29,7 @@ from kojismokydingo.sift import (
 from kojismokydingo.sift.parse import (
     AllItems, Glob, Item, ItemMatch, ItemPath,
     Null, Number, ParserError, Regex, Symbol, SymbolGroup,
+    convert_token,
 )
 
 
@@ -993,6 +994,19 @@ class EnsureTypeTest(TestCase):
         self.assertRaises(SifterError, ensure_all_symbol, bad_values)
 
 
+    def test_ensure_symbol_expand(self):
+
+        values = [Symbol("Hi"), convert_token("{Hello,Goodbye}World")]
+        expect = [Symbol("Hi"), Symbol("HelloWorld"), Symbol("GoodbyeWorld")]
+
+        res = ensure_all_symbol(values)
+        self.assertEqual(len(res), 3)
+        self.assertEqual(res, expect)
+
+        self.assertRaises(SifterError, ensure_all_symbol, values,
+                          expand=False)
+
+
 class EnsureTypeSieveTest(TestCase):
 
 
@@ -1029,6 +1043,14 @@ class EnsureTypeSieveTest(TestCase):
                       Glob("*"), Regex(".*"), [], ())
 
         self.assertRaises(SifterError, ExSymbolSieve, None, *bad_values)
+
+
+    def test_symbol_sieve_expand(self):
+        good_values = (convert_token("{Hello,Goodbye}"), Symbol("World"))
+        expect = (Symbol("Hello"), Symbol("Goodbye"), Symbol("World"))
+
+        vals = ExSymbolSieve(Sifter((), ""), *good_values).tokens
+        self.assertEqual(expect, vals)
 
 
 #

--- a/tests/sift/__init__.py
+++ b/tests/sift/__init__.py
@@ -809,6 +809,21 @@ class SifterTest(TestCase):
         self.assertEqual(res["default"], [DRAINO])
 
 
+    def test_alias(self):
+        src = """
+        (poke) (incr)
+        """
+        sifter = self.compile_sifter(src)
+        sieves = sifter.sieve_exprs()
+        self.assertEqual(len(sieves), 2)
+
+        poke = sieves[0]
+        incr = sieves[1]
+
+        self.assertTrue(type(poke) is Poke)
+        self.assertTrue(type(poke) is type(incr))
+
+
     def test_cache(self):
 
         src = """

--- a/tests/sift/parse.py
+++ b/tests/sift/parse.py
@@ -468,6 +468,19 @@ class ParserTest(TestCase):
         self.assertNotEqual(res[0], "hig")
         self.assertNotEqual(res[0], "hgh")
 
+        src="""
+        hi{,,gh,}
+        """
+        res = self.parse(src)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(type(res[0]), SymbolGroup)
+        self.assertEqual(repr(res[0]), "SymbolGroup('hi{,,gh,}')")
+        self.assertEqual(res[0], "hi")
+        self.assertEqual(res[0], "high")
+        self.assertNotEqual(res[0], "hi gh")
+        self.assertNotEqual(res[0], "hig")
+        self.assertNotEqual(res[0], "hgh")
+
         src = """
         hi{foo,bar}
         """

--- a/tests/sift/parse.py
+++ b/tests/sift/parse.py
@@ -442,6 +442,32 @@ class ParserTest(TestCase):
         self.assertNotEqual(res[0], "foo00")
         self.assertNotEqual(res[0], "foo06")
 
+        src="""
+        hi{,gh}
+        """
+        res = self.parse(src)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(type(res[0]), SymbolGroup)
+        self.assertEqual(repr(res[0]), "SymbolGroup('hi{,gh}')")
+        self.assertEqual(res[0], "hi")
+        self.assertEqual(res[0], "high")
+        self.assertNotEqual(res[0], "hi gh")
+        self.assertNotEqual(res[0], "hig")
+        self.assertNotEqual(res[0], "hgh")
+
+        src="""
+        hi{gh,}
+        """
+        res = self.parse(src)
+        self.assertEqual(len(res), 1)
+        self.assertEqual(type(res[0]), SymbolGroup)
+        self.assertEqual(repr(res[0]), "SymbolGroup('hi{gh,}')")
+        self.assertEqual(res[0], "hi")
+        self.assertEqual(res[0], "high")
+        self.assertNotEqual(res[0], "hi gh")
+        self.assertNotEqual(res[0], "hig")
+        self.assertNotEqual(res[0], "hgh")
+
         src = """
         hi{foo,bar}
         """

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -12,7 +12,7 @@ function whichever() {
 
 
 function ksd_version() {
-    local PYTHON=$(whichever python python2 python3)
+    local PYTHON=$(whichever python3 python python2)
     read -r -d'\0' SCRIPT <<EOF
 from __future__ import print_function
 import setup


### PR DESCRIPTION
Closes #67 

- convenience
- initial tag filtering sieves
- tag deduping
- filter-tags command
- fix ItemPath slightly
- include filter-tags in docs, with testing
- ksd-filter-tags standalone
- correct docstr and make name optional
- refactor the token type testing into new base classes
- unused imports
- flesh out tag predicate docs
- dest-tag and build-tag sieves
- easier to read
- tag predicates parent and inherits
- allow sieves to provide aliases. add inheritance-checking tag sieves
- distinct tests for sieve aliases
- renamed method
- correct underline
- adding compare-latest, latest, and tagged predicates
- allow ensure_all_symbol to expand SymbolGroup values to their combined symbols
- add build predicate 'pkg-unlisted'
- tag predicates pkg-allowed, pkg-blocked, pkg-unlisted
- update spec to include ksd-filter-tags, update docs
- add rpm and archive to the types supported by the open command
- ksd-filter-tags
- missing test for commands
- cleanup for the packaging tests
- Initialized to use tito.
- found an issue with some symbol group parsing around empty elements
- slightly more gross test
- additional cache methods
- tag predicates for checking install groups
- docs for all-group-pkg, group, and group-pkg
