### PR TITLE
Sieve options keyword syntax

### DIFF
--- a/docs/release_notes/v0.9.6.rst
+++ b/docs/release_notes/v0.9.6.rst
@@ -32,3 +32,5 @@ Otherwise, still chugging along!
   page for the relevant koji data type.
 - Added 'koji filter-tags' command and 'ksd-filter-tags' standalone
   command for applying sifty predicates to filter a list of tags
+- Sieve predicats may now accept options via a keyword-like syntax if
+  they supply a 'set_options' method.

--- a/docs/siftylang.rst
+++ b/docs/siftylang.rst
@@ -53,6 +53,8 @@ Sieve Predicate
 
   (foo)
   (foo 1 two "three" /four/ |five|)
+  (bar x y)
+  (bar x y optional: True)
   (and (foo 1) (bar 2))
   (or (baz 3) (and (qux) (quux 4)))
 
@@ -83,6 +85,10 @@ numeric -- it would instead be interpreted as a Number in that case.
 Symbols with a leading dollar-sign are interpreted as variables, and
 their value will be substituted from a sifter parameter at compile
 time.
+
+When used as arguments to a sieve predicate, symbols with a trailing
+``':`` character are treated as keyword markers. The value following a
+keyword marker is used as the keywords argument.
 
 
 Number
@@ -602,16 +608,6 @@ A sifter instance with these and the core sieves available by default can be
 created via :py:func:`kojismokydingo.sift.tags.tag_info_sifter`
 
 
-Tag Predicate ``all-group-pkg``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-::
-
-   (all-group-pkg GROUP PKG [PKG...])
-
-Matches tags which have the given install group, which must also
-contain all of the given ``PKG`` names
-
-
 Tag Predicate ``arch``
 ^^^^^^^^^^^^^^^^^^^^^^
 ::
@@ -706,10 +702,13 @@ Honors inheritance.
 Tag Predicate ``group-pkg``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ::
-   (group-pkg GROUP PKG [PKG...])
+   (group-pkg GROUP PKG [PKG...] [requireAll: False])
 
 Matches tags which have the given install group, which also contains
-any of the given ``PKG`` names
+any of the given ``PKG`` names.
+
+If ``requireAll`` is set to ``True`` then all of the given ``PKG``
+names must be present in order for a tag to match.
 
 
 Tag Predicate ``has-ancestor``

--- a/docs/siftylang.rst
+++ b/docs/siftylang.rst
@@ -87,8 +87,10 @@ their value will be substituted from a sifter parameter at compile
 time.
 
 When used as arguments to a sieve predicate, symbols with a trailing
-``':`` character are treated as keyword markers. The value following a
-keyword marker is used as the keywords argument.
+``:`` character are treated as keyword markers. The value following a
+keyword marker is used as the keyword's argument. They keyword and its
+value form an option pair, which is fed into the sieve via its
+`set_options` method.
 
 
 Number

--- a/kojismokydingo/sift/parse.py
+++ b/kojismokydingo/sift/parse.py
@@ -564,6 +564,8 @@ def convert_token(val):
 
     * An all-digit value will become Number
     * None, null, nil become a Null
+    * True becomes the boolean True
+    * False becomes the boolean False
     * Use of {} may become a SymbolGroup or Symbol
     * Everything else becomes a Symbol.
 
@@ -575,6 +577,14 @@ def convert_token(val):
 
     if val in (None, "None", "null", "nil"):
         return Null()
+
+    elif val is True or val == "True":
+        # note, we do not use 'in' because 1 would match as True
+        return True
+
+    elif val is False or val == "False":
+        # note, we do not use 'in' because 0 would match as False
+        return False
 
     elif NUMBER_RE == val:
         return Number(val)
@@ -592,7 +602,6 @@ def convert_token(val):
                 return Symbol(val)
             else:
                 return SymbolGroup(val, grps)
-
         else:
             return Symbol(val)
 

--- a/kojismokydingo/sift/tags.py
+++ b/kojismokydingo/sift/tags.py
@@ -44,7 +44,6 @@ from ..tags import (
 __all__ = (
     "DEFAULT_TAG_INFO_SIEVES",
 
-    "AllGroupPkgSieve",
     "ArchSieve",
     "BuildTagSieve",
     "CompareLatestSieve",
@@ -732,6 +731,11 @@ class GroupPkgSieve(SymbolSieve, CacheMixin):
         self.group = ensure_symbol(group)
 
 
+    def set_options(self, require_all=False):
+        super(GroupPkgSieve, self).set_options(require_all=require_all)
+        self.require_all = bool(require_all)
+
+
     def prep(self, session, taginfos):
 
         needed = {}
@@ -758,11 +762,23 @@ class GroupPkgSieve(SymbolSieve, CacheMixin):
         if not pkgs:
             return False
 
-        for tok in self.tokens:
-            if tok in pkgs:
+        if self.require_all:
+            # require all tokens to be present
+            for tok in self.tokens:
+                if tok not in pkgs:
+                    return False
+            else:
                 return True
+
         else:
-            return False
+            # if any token is present, we match
+            for tok in self.tokens:
+                if tok in pkgs:
+                    return True
+            else:
+                return False
+
+
 
 
 class AllGroupPkgSieve(GroupPkgSieve):
@@ -788,12 +804,6 @@ class AllGroupPkgSieve(GroupPkgSieve):
         pkgs = groups.get(self.group)
         if not pkgs:
             return False
-
-        for tok in self.tokens:
-            if tok not in pkgs:
-                return False
-        else:
-            return True
 
 
 DEFAULT_TAG_INFO_SIEVES = [

--- a/tests/sift/parse.py
+++ b/tests/sift/parse.py
@@ -242,31 +242,25 @@ class ParserTest(TestCase):
         self.assertEqual(res, [Symbol("foo"), Symbol("bar")])
 
 
-    def check_null(self, src):
-        res = self.parse(src)
-        self.assertEqual(len(res), 1)
-        self.assertEqual(type(res[0]), Null)
-        self.assertEqual(str(res[0]), "null")
-        self.assertEqual(repr(res[0]), "Null()")
-
-
     def test_null(self):
-        sources = [
-            """
-            None
-            """,
+        for src in ("None", "null", "nil"):
+            res = self.parse(src)
+            self.assertEqual(len(res), 1)
+            self.assertEqual(type(res[0]), Null)
+            self.assertEqual(str(res[0]), "null")
+            self.assertEqual(repr(res[0]), "Null()")
 
-            """
-            null
-            """,
 
-            """
-            nil
-            """,
-        ]
+    def test_bool(self):
+        src = "True False"
+        res = self.parse(src)
 
-        for src in sources:
-            self.check_null(src)
+        self.assertEqual(len(res), 2)
+        self.assertEqual(type(res[0]), bool)
+        self.assertEqual(type(res[1]), bool)
+
+        self.assertTrue(res[0] is True)
+        self.assertTrue(res[1] is False)
 
 
     def test_quoted(self):


### PR DESCRIPTION
Adds keyword syntax to sifty sieves, allowing predicates to set options distinct from their positional arguments.

eg. ``(foo a b more: True)`` would create a sieve with the positional arguments ``[a, b]`` and options ``{"more": True}``