### PR TITLE
Sieve entry points

### DIFF
--- a/docs/commands/filter-builds.rst
+++ b/docs/commands/filter-builds.rst
@@ -15,6 +15,7 @@ koji filter-builds
                            [--win] [-c CG_NAME] [--imports | --no-imports]
                            [--completed | --deleted] [--param KEY=VALUE]
                            [--env-params] [--output FLAG:FILENAME]
+                           [--no-entry-points]
                            [--filter FILTER | --filter-file FILTER_FILE]
                            [NVR [NVR ...]]
 
@@ -81,6 +82,8 @@ koji filter-builds
                          If FILENAME is '-', output to stdout. The 'default'
                          flag is output to stdout by default, and other flags
                          are discarded
+   --no-entry-points, -n
+                         Disable loading of additional sieves from entry_points
    --filter FILTER       Use the given sifty filter predicates
    --filter-file FILTER_FILE
                          Load sifty filter predictes from file

--- a/docs/commands/filter-tags.rst
+++ b/docs/commands/filter-tags.rst
@@ -10,6 +10,7 @@ koji filter-tags
                          [--search GLOB | --regex REGEX]
                          [--nvr-sort | --id-sort] [--param KEY=VALUE]
                          [--env-params] [--output FLAG:FILENAME]
+                         [--no-entry-points]
                          [--filter FILTER | --filter-file FILTER_FILE]
                          [TAGNNAME [TAGNNAME ...]]
 
@@ -46,6 +47,8 @@ koji filter-tags
                          If FILENAME is '-', output to stdout. The 'default'
                          flag is output to stdout by default, and other flags
                          are discarded
+   --no-entry-points, -n
+                         Disable loading of additional sieves from entry_points
    --filter FILTER       Use the given sifty filter predicates
    --filter-file FILTER_FILE
                          Load sifty filter predictes from file

--- a/docs/commands/list-component-builds.rst
+++ b/docs/commands/list-component-builds.rst
@@ -17,7 +17,7 @@ koji list-component-builds
                                    [--imports | --no-imports]
                                    [--completed | --deleted]
                                    [--param KEY=VALUE] [--env-params]
-                                   [--output FLAG:FILENAME]
+                                   [--output FLAG:FILENAME] [--no-entry-points]
                                    [--filter FILTER | --filter-file FILTER_FILE]
                                    [NVR [NVR ...]]
 
@@ -84,6 +84,8 @@ koji list-component-builds
                          If FILENAME is '-', output to stdout. The 'default'
                          flag is output to stdout by default, and other flags
                          are discarded
+   --no-entry-points, -n
+                         Disable loading of additional sieves from entry_points
    --filter FILTER       Use the given sifty filter predicates
    --filter-file FILTER_FILE
                          Load sifty filter predictes from file

--- a/docs/release_notes/v0.9.6.rst
+++ b/docs/release_notes/v0.9.6.rst
@@ -34,3 +34,7 @@ Otherwise, still chugging along!
   command for applying sifty predicates to filter a list of tags
 - Sieve predicats may now accept options via a keyword-like syntax if
   they supply a 'set_options' method.
+- Enable loading of additional sieves via entry_points for the
+  'filter-tags', 'filter-builds', and 'list-component-builds' koji
+  commands and the 'ksd-filter-tags' and 'ksd-filter-builds'
+  standalone commands.

--- a/docs/siftylang.rst
+++ b/docs/siftylang.rst
@@ -599,6 +599,21 @@ Filters for builds which have a version matching any of the given
 ``VER`` patterns.
 
 
+Add-On Build Predicates
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The koji plugin commands ``filter-builds`` and
+``list-component-builds``, and the standalone command
+``ksd-filter-tags`` will attempt to load additional user-defined build
+sieves utilizing Python entry_points. This behavior may be disabled by
+with the ``--no-entry-points`` option.
+
+In order to provide additional tag sieves, a Python package must
+supply an entry_point to a nullary function which will return a list
+of Sieve classes, under the group named
+``koji_smoky_dingo_build_sieves``
+
+
 Tag Sieves
 ----------
 
@@ -829,3 +844,17 @@ Tag Predicate ``pkg-unlisted``
 
 Matches tags which have no package listing (neither allowed nor
 blocked) for any of the given ``PKG`` names. Honors inheritance.
+
+
+Add-On Tag Predicates
+^^^^^^^^^^^^^^^^^^^^^
+
+The koji plugin command ``filter-tags`` and the standalone command
+``ksd-filter-tags`` will attempt to load additional user-defined tag
+sieves utilizing Python entry_points. This behavior may be disabled by
+with the ``--no-entry-points`` option.
+
+In order to provide additional tag sieves, a Python package must
+supply an entry_point to a nullary function which will return a list
+of Sieve classes, under the group named
+``koji_smoky_dingo_tag_sieves``

--- a/kojismokydingo.spec
+++ b/kojismokydingo.spec
@@ -236,6 +236,10 @@ Koji Smoky Dingo
   page for the relevant koji data type.
 - Added 'koji filter-tags' command and 'ksd-filter-tags' standalone
   command for applying sifty predicates to filter a list of tags
+- Enable loading of additional sieves via entry_points for the
+  'filter-tags', 'filter-builds', and 'list-component-builds' koji
+  commands and the 'ksd-filter-tags' and 'ksd-filter-builds'
+  standalone commands.
 
 * Fri Dec 18 2020 Christopher O'Brien <obriencj@gmail.com> - 0.9.5-1
 - remove install_requires for koji, because koji doesn't think it's a

--- a/kojismokydingo/sift/builds.py
+++ b/kojismokydingo/sift/builds.py
@@ -23,8 +23,6 @@ dicts.
 """
 
 
-import operator
-
 from abc import abstractmethod
 from koji import BUILD_STATES
 from operator import itemgetter


### PR DESCRIPTION
Closes #68 

Enable loading of additional sieves via entry_points for the 'filter-tags', 'filter-builds', and 'list-component-builds' koji commands and the 'ksd-filter-tags' and 'ksd-filter-builds' standalone commands.
