### PR TITLE
Plugin config

### DIFF
--- a/kojismokydingo/cli/__init__.py
+++ b/kojismokydingo/cli/__init__.py
@@ -41,6 +41,7 @@ from six import add_metaclass
 from six.moves import StringIO, filter, map, zip_longest
 
 from .. import BadDingo, NotPermitted
+from ..conf import load_plugin_config
 
 
 __all__ = (
@@ -463,10 +464,21 @@ class SmokyDingo(object):
                 desc = "[%s] %s" % (self.group, desc)
             self.__doc__ = desc
 
+        # populated by the get_plugin_config method
+        self.config = None
+
         # these will be populated once the command instance is
         # actually called
         self.goptions = None
         self.session = None
+
+
+    def get_plugin_config(self, key, default=None):
+        if self.config is None:
+            profile = self.goptions.profile if self.goptions else None
+            self.config = load_plugin_config(self.name, profile)
+
+        return self.config.get(key, default)
 
 
     def parser(self):

--- a/kojismokydingo/cli/clients.py
+++ b/kojismokydingo/cli/clients.py
@@ -33,6 +33,7 @@ from .. import (
     as_archiveinfo, as_buildinfo, as_hostinfo, as_rpminfo,
     as_taginfo, as_targetinfo, as_taskinfo, as_userinfo, )
 from ..clients import rebuild_client_config
+from ..conf import load_plugin_config
 
 
 def cli_client_config(session, goptions,
@@ -142,6 +143,38 @@ OPEN_URL = {
 }
 
 
+def get_open_command(profile=None, err=True):
+    """
+    Determine the command used to open URLs. Attempts to load
+    profile-specific plugin configuration under the heading 'open' and
+    the key 'command' first. If that doesn't find a command, then fall
+    back to the per-platform mappings in the `OPEN_CMD` dict.
+
+    :param profile: name of koji profile
+
+    :type profile: str, optional
+
+    :param err: raise an exception if no command is discovered. If False
+      then will return None instead
+
+    :type err: bool, optional
+
+    :rtype: str
+
+    :raises BadDingo: when `err` is True and no command could be found
+    """
+
+    default_command = OPEN_CMD.get(sys.platform)
+
+    conf = load_plugin_config("open", profile)
+    command = conf.get("command", default_command)
+
+    if err and command is None:
+        raise BadDingo("Unable to determine command for launching browser")
+
+    return command
+
+
 def cli_open(session, goptions, datatype, element,
              command=None):
 
@@ -152,10 +185,7 @@ def cli_open(session, goptions, datatype, element,
         raise BadDingo("Unsupported type for open %s" % datatype)
 
     if command is None:
-        command = OPEN_CMD.get(sys.platform)
-
-    if command is None:
-        raise BadDingo("Unable to determine command for launching browser")
+        command = get_open_command(goptions.profile)
 
     weburl = goptions.weburl
     if not weburl:

--- a/kojismokydingo/conf.py
+++ b/kojismokydingo/conf.py
@@ -28,20 +28,32 @@ from os.path import expanduser, isdir, join
 from six.moves.configparser import ConfigParser
 
 
+try:
+    import appdirs
+except ImportError:
+    appdirs = None
+
+
+__all__ = (
+    "find_config_dirs",
+    "find_config_files",
+    "get_plugin_config",
+    "load_full_config",
+    "load_plugin_config",
+)
+
+
 def find_config_dirs():
     """
-    The site and user configuration dirs, as a tuple
+    The site and user configuration dirs, as a tuple. Attempts to use
+    the ``appdirs`` package if it is available.
 
     :rtype: tuple[str]
     """
 
-    try:
-        import appdirs
-
-    except ImportError:
+    if appdirs is None:
         site_conf_dir = "/etc/ksd/"
         user_conf_dir = expanduser("~/.config/ksd/")
-
     else:
         site_conf_dir = appdirs.site_config_dir("ksd")
         user_conf_dir = appdirs.user_config_dir("ksd")
@@ -54,7 +66,11 @@ def find_config_files(dirs=None):
     The ordered list of configuration files to be loaded.
 
     If `dirs` is specified, it must be a sequence of directory names,
-    from which conf files will be loaded in order.
+    from which conf files will be loaded in order. If unspecified,
+    defaults to the result of `find_config_dirs`
+
+    :param dirs: list of directories to look for config files within
+    :type dirs: list[str], optional
 
     :rtype: list[str]
     """
@@ -115,14 +131,14 @@ def get_plugin_config(conf, plugin, profile=None):
         plugin_conf.update(conf.items(plugin))
 
     if profile is not None:
-        profile = ":".join(plugin, profile)
+        profile = ":".join((plugin, profile))
         if conf.has_section(profile):
             plugin_conf.update(conf.items(profile))
 
     return plugin_conf
 
 
-def load_config(plugin, profile=None):
+def load_plugin_config(plugin, profile=None):
     """
     Configuration specific to a given plugin, and optionally profile
 

--- a/kojismokydingo/conf.py
+++ b/kojismokydingo/conf.py
@@ -92,7 +92,7 @@ def load_full_config(config_files=None):
     return conf
 
 
-def get_pugin_config(conf, plugin, profile=None):
+def get_plugin_config(conf, plugin, profile=None):
     """
     Given a loaded configuration, return the section specific to the
     given plugin, and optionally profile

--- a/kojismokydingo/conf.py
+++ b/kojismokydingo/conf.py
@@ -1,0 +1,143 @@
+# This library is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses/>.
+
+
+"""
+Koji Smoky Dingo - client plugin configuration
+
+This module provides a re-usable per-plugin (and optionally
+per-profile) configuration mechanism.
+
+:author: Christopher O'Brien <obriencj@gmail.com>
+:license: GPL v3
+"""
+
+
+from glob import glob
+from os.path import expanduser, isdir, join
+from six.moves.configparser import ConfigParser
+
+
+def find_config_dirs():
+    """
+    The site and user configuration dirs, as a tuple
+
+    :rtype: tuple[str]
+    """
+
+    try:
+        import appdirs
+
+    except ImportError:
+        site_conf_dir = "/etc/ksd/"
+        user_conf_dir = expanduser("~/.config/ksd/")
+
+    else:
+        site_conf_dir = appdirs.site_config_dir("ksd")
+        user_conf_dir = appdirs.user_config_dir("ksd")
+
+    return (site_conf_dir, user_conf_dir)
+
+
+def find_config_files(dirs=None):
+    """
+    The ordered list of configuration files to be loaded.
+
+    If `dirs` is specified, it must be a sequence of directory names,
+    from which conf files will be loaded in order.
+
+    :rtype: list[str]
+    """
+
+    if dirs is None:
+        dirs = find_config_dirs()
+
+    found = []
+
+    for confdir in dirs:
+        if isdir(confdir):
+            wanted = join(confdir, "*.conf")
+            found.extend(sorted(glob(wanted)))
+
+    return found
+
+
+def load_full_config(config_files=None):
+    """
+    Configuration object representing the full merged view of config
+    files.
+
+    If `config_files` is None, use the results of `find_config_files`.
+    Otherwise, `config_files` must be a sequence of filenames.
+
+    :rtype: ConfigParser
+    """
+
+    if config_files is None:
+        config_files = find_config_files()
+
+    conf = ConfigParser()
+    conf.read(config_files)
+
+    return conf
+
+
+def get_pugin_config(conf, plugin, profile=None):
+    """
+    Given a loaded configuration, return the section specific to the
+    given plugin, and optionally profile
+
+    :param conf: Full configuration
+    :type conf: ConfigParser
+
+    :param plugin: Plugin name
+    :type plugin: str
+
+    :param profile: Profile name
+    :type profile: str, optional
+
+    :rtype: dict[str,object]
+    """
+
+    plugin_conf = {}
+
+    if conf.has_section(plugin):
+        plugin_conf.update(conf.items(plugin))
+
+    if profile is not None:
+        profile = ":".join(plugin, profile)
+        if conf.has_section(profile):
+            plugin_conf.update(conf.items(profile))
+
+    return plugin_conf
+
+
+def load_config(plugin, profile=None):
+    """
+    Configuration specific to a given plugin, and optionally profile
+
+    :param plugin: Plugin name
+    :type plugin: str
+
+    :param profile: Profile name
+    :type profile: str, optional
+
+    :rtype: dict[str,object]
+    """
+
+    conf = load_full_config()
+    return get_plugin_config(conf, plugin, profile)
+
+
+#
+# The end.

--- a/kojismokydingo/conf.py
+++ b/kojismokydingo/conf.py
@@ -52,7 +52,7 @@ def find_config_dirs():
     """
 
     if appdirs is None:
-        site_conf_dir = "/etc/ksd/"
+        site_conf_dir = "/etc/xdg/ksd/"
         user_conf_dir = expanduser("~/.config/ksd/")
     else:
         site_conf_dir = appdirs.site_config_dir("ksd")

--- a/setup.py
+++ b/setup.py
@@ -101,11 +101,13 @@ def config():
         ],
 
         "install_requires": [
+            "appdirs",
             "koji",
             "six",
         ],
 
         "tests_require": [
+            "appdirs",
             "docutils",
             "koji",
             "mock",

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -1,0 +1,84 @@
+# This library is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this library; if not, see <http://www.gnu.org/licenses/>.
+
+
+from pkg_resources import resource_filename
+from six.moves.configparser import ConfigParser
+from unittest import TestCase
+
+from kojismokydingo.conf import (
+    find_config_files,
+    load_full_config,
+    get_plugin_config,
+)
+
+
+def test_dirs():
+    return (resource_filename(__name__, "data/system"),
+            resource_filename(__name__, "data/user"))
+
+
+class TestConfig(TestCase):
+
+    def test_find_files(self):
+        dirs = test_dirs()
+        found = find_config_files(dirs)
+
+        self.assertEqual(len(found), 3)
+
+
+    def test_load(self):
+        dirs = test_dirs()
+        files = find_config_files(dirs)
+        conf = load_full_config(files)
+
+        self.assertTrue(isinstance(conf, ConfigParser))
+        self.assertTrue(conf.has_section("example_1"))
+        self.assertTrue(conf.has_section("example_2"))
+        self.assertTrue(conf.has_section("example_2:test"))
+        self.assertTrue(conf.has_section("example_3"))
+        self.assertTrue(conf.has_section("example_3:test"))
+        self.assertTrue(conf.has_section("example_3:foo"))
+
+
+    def test_merge(self):
+        dirs = test_dirs()
+        files = find_config_files(dirs)
+        full_conf = load_full_config(files)
+
+        conf = get_plugin_config(full_conf, "example_1")
+        self.assertTrue(conf)
+        self.assertEqual(type(conf), dict)
+        self.assertEqual(conf["data"], '111')
+        self.assertEqual(conf["flavor"], 'tasty')
+
+        conf = get_plugin_config(full_conf, "example_2")
+        self.assertTrue(conf)
+        self.assertEqual(type(conf), dict)
+        self.assertEqual(conf["data"], '244')
+        self.assertEqual(conf["flavor"], 'meh')
+
+        conf = get_plugin_config(full_conf, "example_2", "test")
+        self.assertTrue(conf)
+        self.assertEqual(type(conf), dict)
+        self.assertEqual(conf["data"], '220')
+        self.assertEqual(conf["flavor"], 'meh')
+
+        conf = get_plugin_config(full_conf, "example_3")
+        self.assertTrue(conf)
+        self.assertEqual(type(conf), dict)
+        self.assertEqual(conf["data"], '300')
+
+
+#
+# The end.

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -53,7 +53,7 @@ class TestConfig(TestCase):
             dirs = find_config_dirs()
 
         self.assertEqual(len(dirs), 2)
-        self.assertEqual(dirs[0], "/etc/ksd/")
+        self.assertEqual(dirs[0], "/etc/xdg/ksd/")
         self.assertTrue(dirs[1].endswith(".config/ksd/"))
 
         meh = faux_appdir()

--- a/tests/conf.py
+++ b/tests/conf.py
@@ -12,13 +12,16 @@
 # along with this library; if not, see <http://www.gnu.org/licenses/>.
 
 
+from mock import MagicMock, patch
 from pkg_resources import resource_filename
 from six.moves.configparser import ConfigParser
 from unittest import TestCase
 
 from kojismokydingo.conf import (
+    find_config_dirs,
     find_config_files,
     load_full_config,
+    load_plugin_config,
     get_plugin_config,
 )
 
@@ -28,19 +31,54 @@ def test_dirs():
             resource_filename(__name__, "data/user"))
 
 
+def faux_appdir():
+    fakes = test_dirs()
+
+    obj = MagicMock()
+
+    site_config_dir = obj.site_config_dir
+    site_config_dir.side_effect = [fakes[0]]
+
+    user_config_dir = obj.user_config_dir
+    user_config_dir.side_effect = [fakes[1]]
+
+    return obj
+
+
 class TestConfig(TestCase):
 
+
+    def test_find_dirs(self):
+        with patch('kojismokydingo.conf.appdirs', new=None):
+            dirs = find_config_dirs()
+
+        self.assertEqual(len(dirs), 2)
+        self.assertEqual(dirs[0], "/etc/ksd/")
+        self.assertTrue(dirs[1].endswith(".config/ksd/"))
+
+        meh = faux_appdir()
+        with patch('kojismokydingo.conf.appdirs', new=meh):
+            dirs = find_config_dirs()
+
+        self.assertEqual(len(dirs), 2)
+        self.assertEqual(dirs, test_dirs())
+        self.assertEqual(meh.site_config_dir.call_count, 1)
+        self.assertEqual(meh.user_config_dir.call_count, 1)
+
+
     def test_find_files(self):
-        dirs = test_dirs()
-        found = find_config_files(dirs)
+
+        with patch('kojismokydingo.conf.appdirs', new=faux_appdir()) as meh:
+            found = find_config_files()
 
         self.assertEqual(len(found), 3)
+        self.assertEqual(meh.site_config_dir.call_count, 1)
+        self.assertEqual(meh.user_config_dir.call_count, 1)
 
 
-    def test_load(self):
-        dirs = test_dirs()
-        files = find_config_files(dirs)
-        conf = load_full_config(files)
+    def test_load_full_config(self):
+        with patch('kojismokydingo.conf.appdirs', new=faux_appdir()) as meh:
+            conf = load_full_config()
 
         self.assertTrue(isinstance(conf, ConfigParser))
         self.assertTrue(conf.has_section("example_1"))
@@ -49,6 +87,35 @@ class TestConfig(TestCase):
         self.assertTrue(conf.has_section("example_3"))
         self.assertTrue(conf.has_section("example_3:test"))
         self.assertTrue(conf.has_section("example_3:foo"))
+
+
+    def test_load_plugin_config(self):
+        with patch('kojismokydingo.conf.appdirs', new=faux_appdir()):
+            conf = load_plugin_config("example_1")
+            self.assertTrue(conf)
+            self.assertEqual(type(conf), dict)
+            self.assertEqual(conf["data"], '111')
+            self.assertEqual(conf["flavor"], 'tasty')
+
+        with patch('kojismokydingo.conf.appdirs', new=faux_appdir()):
+            conf = load_plugin_config("example_2")
+            self.assertTrue(conf)
+            self.assertEqual(type(conf), dict)
+            self.assertEqual(conf["data"], '244')
+            self.assertEqual(conf["flavor"], 'meh')
+
+        with patch('kojismokydingo.conf.appdirs', new=faux_appdir()):
+            conf = load_plugin_config("example_2", "test")
+            self.assertTrue(conf)
+            self.assertEqual(type(conf), dict)
+            self.assertEqual(conf["data"], '220')
+            self.assertEqual(conf["flavor"], 'meh')
+
+        with patch('kojismokydingo.conf.appdirs', new=faux_appdir()):
+            conf = load_plugin_config("example_3")
+            self.assertTrue(conf)
+            self.assertEqual(type(conf), dict)
+            self.assertEqual(conf["data"], '300')
 
 
     def test_merge(self):

--- a/tests/data/system/a.conf
+++ b/tests/data/system/a.conf
@@ -1,0 +1,11 @@
+[example_1]
+data = 100
+
+[example_2]
+data = 200
+flavor = meh
+
+[example_2:test]
+data = 220
+
+# The end.

--- a/tests/data/system/b.conf
+++ b/tests/data/system/b.conf
@@ -1,0 +1,7 @@
+[example_1]
+data = 101
+
+[example_3]
+data = 300
+
+# The end.

--- a/tests/data/user/a.conf
+++ b/tests/data/user/a.conf
@@ -1,0 +1,14 @@
+[example_1]
+data = 111
+flavor = tasty
+
+[example_2]
+data = 244
+
+[example_3:test]
+data = 333
+
+[example_3:foo]
+data = 344
+
+# The end.


### PR DESCRIPTION
* adds kojismokydingo.conf for loading configuration distinct from koji session options
* configuration sections may be defined with per-profile values
* enable client plugin configuration for the open command's command option

Closes #70 