### PR TITLE
Additional types for the open command

### DIFF
--- a/docs/commands/open.rst
+++ b/docs/commands/open.rst
@@ -5,19 +5,22 @@ koji open
 
 ::
 
- usage: koji open [-h] [--command COMMAND] TYPE KEY
+ usage: koji open [-h] [--command COMMAND | --print] TYPE KEY
 
  Launch web UI for koji data elements
 
  positional arguments:
-   TYPE                  The koji data element type. build, tag, target, user,
-                         host, rpm, archive, task
+   TYPE                  The koji data element type. Supported types: archive,
+                         build, build-dir, host, repo, rpm, tag, tag-latest-
+                         dir, tag-repo-dir, target, task, user
    KEY                   The key for the given element type.
 
  optional arguments:
    -h, --help            show this help message and exit
    --command COMMAND, -c COMMAND
                          Command to exec with the discovered koji web URL
+   --print, -p           Print URL to stdout rather than executing a command
+
 
 Launch local web browser to the informational page for a given koji data
 element.

--- a/docs/commands/open.rst
+++ b/docs/commands/open.rst
@@ -25,6 +25,20 @@ koji open
 Launch local web browser to the informational page for a given koji data
 element.
 
+The types ``archive``, ``build``, ``channel``, ``host``, ``package``,
+``repo``, ``rpm``, ``tag``, ``target``, ``task``, and ``user`` all
+open the relevant koji web info page if a matching element could be
+found.
+
+The type ``tag-latest-dir`` accepts a tag as the argument, and will
+open the tag's latest repository directory.
+
+The type ``tag-repo-dir`` works similar to ``tag-latest-dir`` but
+points to the actual repo ID path rather than the ``latest`` symlink.
+
+The type ``build-dir`` accepts a build as the argument, and will open
+the storage directory for that build's archives and logs.
+
 
 References
 ----------

--- a/docs/commands/open.rst
+++ b/docs/commands/open.rst
@@ -11,8 +11,8 @@ koji open
 
  positional arguments:
    TYPE                  The koji data element type. Supported types: archive,
-                         build, build-dir, host, repo, rpm, tag, tag-latest-
-                         dir, tag-repo-dir, target, task, user
+                         build, build-dir, channel, host, package, repo, rpm,
+                         tag, tag-latest-dir, tag-repo-dir, target, task, user
    KEY                   The key for the given element type.
 
  optional arguments:

--- a/docs/commands/open.rst
+++ b/docs/commands/open.rst
@@ -25,6 +25,14 @@ koji open
 Launch local web browser to the informational page for a given koji data
 element.
 
+The ``--command=COMMAND`` option can be specified to pass the relevant
+URL to an arbitrary executable rather than the platform-default URL
+opener.  On linux, the default command is ``xdg-open``, on macOS it is
+``open`` and on Microsoft Windows it is ``start``. The default can
+also be set as a plugin configuration as the value ``command`` under
+the ``[open]`` section header. The return code of the executed command
+will become the return code of the ``koji open`` invocation.
+
 The types ``archive``, ``build``, ``channel``, ``host``, ``package``,
 ``repo``, ``rpm``, ``tag``, ``target``, ``task``, and ``user`` all
 open the relevant koji web info page if a matching element could be
@@ -45,3 +53,5 @@ References
 
 * :py:obj:`kojismokydingo.cli.clients.ClientOpen`
 * :py:func:`kojismokydingo.cli.clients.cli_open`
+* :py:func:`kojismokydingo.cli.clients.get_open_command`
+* :py:func:`kojismokydingo.cli.clients.get_open_url`

--- a/docs/release_notes/v2.0.0.rst
+++ b/docs/release_notes/v2.0.0.rst
@@ -17,3 +17,10 @@ exceptions:
   `Sieve.__init__`
 * Moved RPM comparison functions out from `kojismokydingo.common` to
   their own new module `kojismokydingo.rpm`
+* Added as_channelinfo, as_packageinfo, as_repoinfo, NoSuchPackage,
+  NoSuchRepo to the core API
+* Added support for more types to the ``open`` command: channel,
+  package, repo, build-dir, tag-repo-dir, and tag-latest-dir
+* Added ``--print`` option to the ``open`` command
+* Made the ``open`` command return the return code of the URL opening
+  executable

--- a/kojismokydingo/__init__.py
+++ b/kojismokydingo/__init__.py
@@ -40,6 +40,7 @@ __all__ = (
     "NoSuchBuild",
     "NoSuchChannel",
     "NoSuchContentGenerator",
+    "NoSuchPackage",
     "NoSuchPermission",
     "NoSuchRepo",
     "NoSuchRPM",
@@ -52,7 +53,9 @@ __all__ = (
 
     "as_archiveinfo",
     "as_buildinfo",
+    "as_channelinfo",
     "as_hostinfo",
+    "as_packageinfo",
     "as_repoinfo",
     "as_rpminfo",
     "as_taginfo",
@@ -175,6 +178,14 @@ class NoSuchContentGenerator(BadDingo):
     """
 
     complaint = "No such content generator"
+
+
+class NoSuchPackage(BadDingo):
+    """
+    A package was not found
+    """
+
+    complaint = "No such package"
 
 
 class NoSuchTag(BadDingo):
@@ -717,6 +728,33 @@ def as_buildinfo(session, build):
     return info
 
 
+def as_channelinfo(session, channel):
+    """
+    Coerces a channel value into a koji channel info dict.
+
+    If channel is an
+     * int, will attempt to load as a channel ID
+     * str, will attempt to load as a channel name
+     * dict, will presume already a channel info
+
+    :param session: an active koji client session
+
+    :param channel: value to lookup
+    """
+
+    if isinstance(channel, (str, int)):
+        info = session.getChannel(channel)
+    elif isinstance(channel, dict):
+        info = channel
+    else:
+        info = None
+
+    if not info:
+        raise NoSuchChannel(channel)
+
+    return info
+
+
 def as_taginfo(session, tag):
     """
     Coerces a tag value into a koji tag info dict.
@@ -826,7 +864,7 @@ def as_hostinfo(session, host):
     """
     Coerces a host value into a host info dict.
 
-    If target is an:
+    If host is an:
      * int, will attempt to load as a host ID
      * str, will attempt to load as a host name
      * dict, will presume already a host info
@@ -850,6 +888,36 @@ def as_hostinfo(session, host):
 
     if not info:
         raise NoSuchHost(host)
+
+    return info
+
+
+def as_packageinfo(session, pkg):
+    """
+    Coerces a host value into a host info dict.
+
+    If pkg is an:
+     * int, will attempt to load as a package ID
+     * str, will attempt to load as a package name
+     * dict, will presume already a package info
+
+    :param session: an active koji client session
+
+    :param pkg: value to lookup
+
+    :raises NoSuchPackage: if the pkg value could not be resolved into
+      a package info dict
+    """
+
+    if isinstance(pkg, (str, int)):
+        info = session.getPackage(pkg)
+    elif isinstance(pkg, dict):
+        info = pkg
+    else:
+        info = None
+
+    if not info:
+        raise NoSuchPackage(pkg)
 
     return info
 

--- a/kojismokydingo/__init__.py
+++ b/kojismokydingo/__init__.py
@@ -183,6 +183,8 @@ class NoSuchContentGenerator(BadDingo):
 class NoSuchPackage(BadDingo):
     """
     A package was not found
+
+    :since: 2.0
     """
 
     complaint = "No such package"
@@ -239,6 +241,8 @@ class NoSuchArchive(BadDingo):
 class NoSuchRepo(BadDingo):
     """
     A repository was not found
+
+    :since: 2.0
     """
 
     complaint = "No such repo"
@@ -740,6 +744,8 @@ def as_channelinfo(session, channel):
     :param session: an active koji client session
 
     :param channel: value to lookup
+
+    :since: 2.0
     """
 
     if isinstance(channel, (str, int)):
@@ -907,6 +913,8 @@ def as_packageinfo(session, pkg):
 
     :raises NoSuchPackage: if the pkg value could not be resolved into
       a package info dict
+
+    :since: 2.0
     """
 
     if isinstance(pkg, (str, int)):
@@ -970,6 +978,8 @@ def as_repoinfo(session, repo):
      * str, will attempt to load the current repo from a tag by name
      * int, will attempt to load the repo by ID
      * dict, will presume already a repo info
+
+    :since: 2.0
     """
 
     info = None

--- a/kojismokydingo/__init__.py
+++ b/kojismokydingo/__init__.py
@@ -41,6 +41,7 @@ __all__ = (
     "NoSuchChannel",
     "NoSuchContentGenerator",
     "NoSuchPermission",
+    "NoSuchRepo",
     "NoSuchRPM",
     "NoSuchTag",
     "NoSuchTarget",
@@ -52,6 +53,7 @@ __all__ = (
     "as_archiveinfo",
     "as_buildinfo",
     "as_hostinfo",
+    "as_repoinfo",
     "as_rpminfo",
     "as_taginfo",
     "as_targetinfo",
@@ -221,6 +223,14 @@ class NoSuchArchive(BadDingo):
     """
 
     complaint = "No such archive"
+
+
+class NoSuchRepo(BadDingo):
+    """
+    A repository was not found
+    """
+
+    complaint = "No such repo"
 
 
 class NoSuchRPM(BadDingo):
@@ -878,6 +888,41 @@ def as_archiveinfo(session, archive):
 
     if not info:
         raise NoSuchArchive(archive)
+
+    return info
+
+
+def as_repoinfo(session, repo):
+    """
+    Coerces a repo value into a Repo info dict.
+
+    If repo is an:
+     * dict with name, will attempt to load the current repo from a
+       tag by that name
+     * str, will attempt to load the current repo from a tag by name
+     * int, will attempt to load the repo by ID
+     * dict, will presume already a repo info
+    """
+
+    info = None
+
+    if isinstance(repo, dict):
+        if "name" in repo:
+            repo = repo["name"]
+        else:
+            info = repo
+
+    if isinstance(repo, str):
+        repotag = session.getRepo(repo)
+        if repotag is None:
+            raise NoSuchRepo(repo)
+        repo = repotag["id"]
+
+    if isinstance(repo, int):
+        info = session.repoInfo(repo)
+
+    if not info:
+        raise NoSuchRepo(repo)
 
     return info
 

--- a/kojismokydingo/__init__.py
+++ b/kojismokydingo/__init__.py
@@ -145,7 +145,7 @@ class BadDingo(Exception):
 
     def __str__(self):
         orig = super().__str__()
-        return ": ".join([self.complaint, orig])
+        return f"{self.complaint}: {orig}"
 
 
 class NoSuchBuild(BadDingo):

--- a/kojismokydingo/cli/clients.py
+++ b/kojismokydingo/cli/clients.py
@@ -51,6 +51,12 @@ __all__ = (
 
 
 class CannotOpenURL(BadDingo):
+    """
+    A problem occured opening a URL
+
+    :since: 2.0
+    """
+
     complaint = "Cannot open URL"
 
 
@@ -61,6 +67,11 @@ def cli_client_config(
         quiet: bool = False,
         config: bool = False,
         json: bool = False):
+    """
+    Implements the ``koji client-config`` command
+
+    :since: 1.0
+    """
 
     profile, opts = rebuild_client_config(session, goptions)
 
@@ -130,10 +141,13 @@ class ClientConfig(AnonSmokyDingo):
                                  json=options.json)
 
 
-def get_build_dir_url(
+def _get_build_dir_url(
         session: ClientSession,
         goptions: object,
         buildid: Union[str, int]) -> str:
+    """
+    :since: 2.0
+    """
 
     topurl: str = goptions.topurl
     if not topurl:
@@ -152,10 +166,13 @@ def get_build_dir_url(
     return f"{topurl}/packages/{name}/{version}/{release}"
 
 
-def get_tag_repo_dir_url(
+def _get_tag_repo_dir_url(
         session: ClientSession,
         goptions: object,
         tagid: Union[str, int]) -> str:
+    """
+    :since: 2.0
+    """
 
     topurl: str = goptions.topurl
     if not topurl:
@@ -168,10 +185,13 @@ def get_tag_repo_dir_url(
     return f"{topurl}/repos/{tag['name']}/{repo['id']}"
 
 
-def get_tag_latest_dir_url(
+def _get_tag_latest_dir_url(
         session: ClientSession,
         goptions: object,
         tagid: Union[str, int]) -> str:
+    """
+    :since: 2.0
+    """
 
     topurl: str = goptions.topurl
     if not topurl:
@@ -199,12 +219,15 @@ OPEN_LOADFN = {
 }
 
 
-def get_type_url(
+def _get_type_url(
         session: ClientSession,
         goptions: object,
         datatype: str,
         fmt: str,
         element: str) -> str:
+    """
+    :since: 2.0
+    """
 
     weburl: str = goptions.weburl
     if not weburl:
@@ -235,9 +258,9 @@ OPEN_URL = {
     "task": "taskinfo?taskID={id}",
     "user": "userinfo?userID={id}",
 
-    "build-dir": get_build_dir_url,
-    "tag-repo-dir": get_tag_repo_dir_url,
-    "tag-latest-dir": get_tag_latest_dir_url,
+    "build-dir": _get_build_dir_url,
+    "tag-repo-dir": _get_tag_repo_dir_url,
+    "tag-latest-dir": _get_tag_latest_dir_url,
 }
 
 
@@ -257,6 +280,8 @@ def get_open_url(
     :param datatype: name of the data type
 
     :param element: identifier for an element of the given data type
+
+    :since: 2.0
     """
 
     opener = OPEN_URL.get(datatype)
@@ -266,7 +291,7 @@ def get_open_url(
     if callable(opener):
         url = opener(session, goptions, element)
     else:
-        url = get_type_url(session, goptions, datatype, opener, element)
+        url = _get_type_url(session, goptions, datatype, opener, element)
 
     return url
 
@@ -293,6 +318,8 @@ def get_open_command(
       then will return None instead
 
     :raises BadDingo: when `err` is `True` and no command could be found
+
+    :since: 1.0
     """
 
     default_command = OPEN_CMD.get(sys.platform)
@@ -312,6 +339,11 @@ def cli_open(
         datatype: str,
         element: str,
         command: Optional[str] = None) -> int:
+    """
+    Implements the ``koji open`` command
+
+    :since: 1.0
+    """
 
     datatype = datatype.lower()
 

--- a/kojismokydingo/cli/clients.py
+++ b/kojismokydingo/cli/clients.py
@@ -39,11 +39,14 @@ from ..common import load_plugin_config
 
 
 __all__ = (
+    "CannotOpenURL",
     "ClientConfig",
     "ClientOpen",
 
     "cli_client_config",
     "cli_open",
+    "get_open_command",
+    "get_open_url",
 )
 
 
@@ -205,7 +208,7 @@ def get_type_url(
 
     weburl: str = goptions.weburl
     if not weburl:
-        raise BadDingo("Client has no weburl configured")
+        raise CannotOpenURL("Client has no weburl configured")
     weburl = weburl.rstrip("/")
 
     loadfn = OPEN_LOADFN.get(datatype)

--- a/kojismokydingo/cli/clients.py
+++ b/kojismokydingo/cli/clients.py
@@ -30,8 +30,9 @@ from typing import Optional, Sequence, Union
 from . import AnonSmokyDingo, int_or_str, pretty_json
 from .. import (
     BadDingo,
-    as_archiveinfo, as_buildinfo, as_hostinfo, as_rpminfo,
-    as_repoinfo, as_taginfo, as_targetinfo, as_taskinfo, as_userinfo, )
+    as_archiveinfo, as_buildinfo, as_channelinfo, as_hostinfo,
+    as_packageinfo, as_rpminfo, as_repoinfo, as_taginfo, as_targetinfo,
+    as_taskinfo, as_userinfo, )
 from ..builds import BUILD_COMPLETE
 from ..clients import rebuild_client_config
 from ..common import load_plugin_config
@@ -183,7 +184,9 @@ def get_tag_latest_dir_url(
 OPEN_LOADFN = {
     "archive": as_archiveinfo,
     "build": as_buildinfo,
+    "channel": as_channelinfo,
     "host": as_hostinfo,
+    "package": as_packageinfo,
     "repo": as_repoinfo,
     "rpm": as_rpminfo,
     "tag": as_taginfo,
@@ -219,9 +222,9 @@ OPEN_URL = {
     "archive": "archiveinfo?archiveID={id}",
     "build": "buildinfo?buildID={id}",
     # "buildroot": "buildrootinfo?buildrootID={id}",
-    # "channel": "channelinfo?channelID={id}",
+    "channel": "channelinfo?channelID={id}",
     "host": "hostinfo?hostID={id}",
-    # "package": "packageinfo?packageID={id}",
+    "package": "packageinfo?packageID={id}",
     "repo": "repoinfo?repoID={id}",
     "rpm": "rpminfo?rpmID={id}",
     "tag": "taginfo?tagID={id}",

--- a/kojismokydingo/clients.py
+++ b/kojismokydingo/clients.py
@@ -22,9 +22,6 @@ Some simple functions for working with the local client configuration
 """
 
 
-import sys
-
-
 __all__ = (
     "rebuild_client_config",
 )

--- a/kojismokydingo/clients.py
+++ b/kojismokydingo/clients.py
@@ -22,6 +22,9 @@ Some simple functions for working with the local client configuration
 """
 
 
+import sys
+
+
 __all__ = (
     "rebuild_client_config",
 )


### PR DESCRIPTION
* Added `as_channelinfo`, `as_packageinfo`, `as_repoinfo`, `NoSuchPackage`, `NoSuchRepo` to the core API
* Added support for more types to the `open` command: channel, package, repo, build-dir, tag-repo-dir, and tag-latest-dir
* Added `--print` option to the `open` command
* Made the `open` command return the return code of the URL opening executable

Closes #93 