### PR TITLE
fix for #95

### DIFF
--- a/kojismokydingo/cli/archives.py
+++ b/kojismokydingo/cli/archives.py
@@ -243,6 +243,13 @@ class LatestArchives(AnonSmokyDingo, ArchiveFiltering):
 
 
     def validate(self, parser, options):
+
+        goptions = self.goptions
+        if options.as_url:
+            options.path = goptions.topurl
+        else:
+            options.path = goptions.topdir
+
         return self.validate_archive_options(parser, options)
 
 


### PR DESCRIPTION
adds missing validation step in the 'koji latest-archives' command