### PR TITLE
new repo-check command

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -17,6 +17,7 @@ do not require any special permissions to run.
    commands/affected-targets
    commands/cginfo
    commands/check-hosts
+   commands/check-repo
    commands/client-config
    commands/filter-builds
    commands/filter-tags

--- a/docs/commands/check-repo.rst
+++ b/docs/commands/check-repo.rst
@@ -1,0 +1,36 @@
+koji check-repo
+===============
+
+.. highlight:: none
+
+::
+
+ usage: koji check-repo [-h] [--target] [--quiet | --verbose] [--utc]
+                        [--events]
+                        TAGNAME
+
+ Check the freshness of a tag's repo
+
+ positional arguments:
+   TAGNAME        Name of tag
+
+ optional arguments:
+   -h, --help     show this help message and exit
+   --target       Specify by target rather than a tag
+   --quiet, -q    Suppress output
+   --verbose, -v  Show history modifications since repo creation
+
+ verbose output settings:
+   --utc          Display timestamps in UTC. Default: show in local
+                  time.Requires koji >= 1.27
+   --events, -e   Display event IDs
+
+
+This command is used to identify whether a tag's repo is out-of-date relative
+to the configuration or builds of the tag or its parents.
+
+In addition to determining whether the repo is fresh or stale, the
+``--verbose`` may be specified to output the combined history of all
+tags in the inheritance past the point that the current repo was
+created. This allows review of what changes may have happened between
+then and now.

--- a/kojismokydingo/__init__.py
+++ b/kojismokydingo/__init__.py
@@ -107,7 +107,7 @@ class ManagedClientSession(ClientSession):
     """
 
     def __enter__(self):
-        activate_session(self, self.opts)
+        self.activate()
         return self
 
 
@@ -117,6 +117,16 @@ class ManagedClientSession(ClientSession):
             self.rsession.close()
             self.rsession = None
         return (exc_type is None)
+
+
+    def activate(self):
+        """
+        Invokes `koji_cli.lib.activate_session` with this session's
+        options, which will trigger the appropriate login method.
+
+        :since 2.0:
+        """
+        return activate_session(self, self.opts)
 
 
     @property
@@ -194,6 +204,17 @@ class AnonClientSession(ProfileClientSession):
 
         # ensure_connection(self)
         return self
+
+
+    def activate(self):
+        """
+        Ensures the anonymous session is connected, but does not attempt
+        to login.
+
+        :since 2.0:
+        """
+
+        ensure_connection(self)
 
 
 class BadDingo(Exception):

--- a/kojismokydingo/cli/__init__.py
+++ b/kojismokydingo/cli/__init__.py
@@ -28,12 +28,14 @@ import sys
 
 from abc import ABCMeta, abstractmethod
 from argparse import Action, ArgumentParser, Namespace
+from collections import namedtuple
 from contextlib import contextmanager
 from functools import partial
 from io import StringIO
 from itertools import zip_longest
 from json import dump
 from koji import ClientSession, GenericError
+from koji_cli.commands import _print_histline
 from koji_cli.lib import activate_session, ensure_connection
 from operator import itemgetter
 from os import devnull
@@ -44,7 +46,7 @@ from typing import (
 
 from .. import BadDingo, NotPermitted
 from ..common import load_plugin_config
-from ..types import GOptions
+from ..types import GOptions, HistoryEntry
 
 
 __all__ = (
@@ -410,6 +412,19 @@ def int_or_str(value: Any) -> Union[int, str]:
         value = str(value)
 
     return value
+
+
+def print_history(
+        timeline: Sequence[HistoryEntry],
+        utc: bool = False,
+        show_events: bool = False,
+        verbose: bool = False):
+
+    Opts = namedtuple('Opts', ['utc', 'events', 'verbose'])
+    options = Opts(utc, show_events, verbose)
+
+    for event in timeline:
+        _print_histline(event, options=options)
 
 
 class SmokyDingo(metaclass=ABCMeta):

--- a/kojismokydingo/types.py
+++ b/kojismokydingo/types.py
@@ -69,6 +69,7 @@ __all__ = (
     "DecoratedTagExtra",
     "DecoratedTagExtras",
     "GOptions",
+    "HistoryEntry",
     "HostInfo",
     "HubVersionSpec",
     "KeySpec",
@@ -1267,6 +1268,9 @@ class GOptions(Values):
     topurl: str
     user: str
     weburl: str
+
+
+HistoryEntry = Tuple[int, str, bool, Dict[str, Any]]
 
 
 #

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ COMMANDS = {
     "bulk-tag-builds": "kojismokydingo.cli.builds:BulkTagBuilds",
     "bulk-untag-builds": "kojismokydingo.cli.builds:BulkUntagBuilds",
     "check-hosts": "kojismokydingo.cli.hosts:CheckHosts",
+    "check-repo": "kojismokydingo.cli.tags:CheckRepo",
     "client-config": "kojismokydingo.cli.clients:ClientConfig",
     "cginfo": "kojismokydingo.cli.users:ShowCGInfo",
     "filter-builds": "kojismokydingo.cli.builds:FilterBuilds",

--- a/stubs/koji/__init__.pyi
+++ b/stubs/koji/__init__.pyi
@@ -540,6 +540,12 @@ class ClientSession:
             notify: bool = False) -> None:
         ...
 
+    def tagChangedSinceEvent(
+            self,
+            event: int,
+            taglist: List[int]) -> bool:
+        ...
+
     def untagBuildBypass(
             self,
             tag: Union[int, str],

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -30,6 +30,7 @@ ENTRY_POINTS = {
     "bulk-untag-builds": "kojismokydingo.cli.builds:BulkUntagBuilds",
     "cginfo": "kojismokydingo.cli.users:ShowCGInfo",
     "check-hosts": "kojismokydingo.cli.hosts:CheckHosts",
+    "check-repo": "kojismokydingo.cli.tags:CheckRepo",
     "client-config": "kojismokydingo.cli.clients:ClientConfig",
     "filter-builds": "kojismokydingo.cli.builds:FilterBuilds",
     "filter-tags": "kojismokydingo.cli.tags:FilterTags",


### PR DESCRIPTION
Closes #106 

Adds a repo-check command which accepts either a tag or target argument, and checks whether the underlying tag has a repo and whether that repo is up-to-date using the same heuristic kojira uses (the tagChangedSinceEvent API)