### PR TITLE
enabled setting for plugin commands

### DIFF
--- a/docs/release_notes/v2.0.0.rst
+++ b/docs/release_notes/v2.0.0.rst
@@ -30,6 +30,8 @@ API
   NoSuchRepo to the core API
 * Added `ManagedClientSession.activate` to allow it to be used more
   conveniently without the managed interface as well
+* Added `SmokyDingo.enabled` property, which loads plugin config to
+  determine if a command should be made available or not
 
 
 Commands

--- a/koji_cli_plugins/kojismokydingometa.py
+++ b/koji_cli_plugins/kojismokydingometa.py
@@ -71,7 +71,7 @@ def __plugin__(glbls):
             # globals for the module. Thus, when the koji plugin
             # loader inspects the contents of this module, it will
             # find the handler with the appropriate name.
-            if handler:
+            if handler and getattr(handler, "enabled", True):
                 glbls[handler.__name__] = handler
 
 

--- a/kojismokydingo/cli/__init__.py
+++ b/kojismokydingo/cli/__init__.py
@@ -30,7 +30,7 @@ from abc import ABCMeta, abstractmethod
 from argparse import Action, ArgumentParser, Namespace
 from collections import namedtuple
 from contextlib import contextmanager
-from functools import partial
+from functools import cached_property, partial
 from io import StringIO
 from itertools import zip_longest
 from json import dump
@@ -664,6 +664,12 @@ class SmokyDingo(metaclass=ABCMeta):
             self.config = load_plugin_config(self.name, profile)
 
         return self.config.get(key, default)
+
+
+    @cached_property
+    def enabled(self):
+        val = self.get_plugin_config("enabled", "1")
+        return val and val.lower() in ("1", "yes", "true")
 
 
     def parser(self) -> ArgumentParser:

--- a/kojismokydingo/common.py
+++ b/kojismokydingo/common.py
@@ -32,6 +32,7 @@ import re
 from configparser import ConfigParser
 from datetime import datetime, timezone
 from fnmatch import fnmatchcase
+from functools import cache
 from glob import glob
 from itertools import filterfalse
 from operator import itemgetter
@@ -454,6 +455,19 @@ def find_config_files(
     return found
 
 
+@cache
+def _load_full_config(
+        config_files: Optional[Tuple[str]] = None) -> ConfigParser:
+
+    if config_files is None:
+        config_files = find_config_files()
+
+    conf = ConfigParser()
+    conf.read(config_files)
+
+    return conf
+
+
 def load_full_config(
         config_files: Optional[Iterable[str]] = None) -> ConfigParser:
     """
@@ -473,13 +487,13 @@ def load_full_config(
     :since: 1.0
     """
 
-    if config_files is None:
-        config_files = find_config_files()
+    # this is actually just a wrapper to a cached call, but we need to
+    # convert to a hashable argument type first.
 
-    conf = ConfigParser()
-    conf.read(config_files)
+    if config_files is not None:
+        config_files = tuple(config_files)
 
-    return conf
+    return _load_full_config(config_files)
 
 
 def get_plugin_config(

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -181,6 +181,11 @@ function ksd_test_platform() {
     # ensure the logdir exists
     mkdir -p "$PWD/logs"
 
+    if selinuxenabled ; then
+        # we will need to allow container access to these three dirs
+        chcon -t container_file_t -R docs logs tests
+    fi
+
     echo "Running tests for $NAME"
     $PODMAN run --rm \
             --volume "$PWD"/docs:/ksd/docs \


### PR DESCRIPTION
Adds a new `enabled` property to the `SmokyDingo` class.

A SmokyDingo instance is considered enabled if its matching section in the plugin configuration either
* has no enabled setting
* has an enabled setting of 1, yes, true

Setting a plugin command's enabled = 0 will cause that command to not be included in the CLI.