### PR TITLE
anonymous group membership access

### DIFF
--- a/docs/commands/userinfo.rst
+++ b/docs/commands/userinfo.rst
@@ -18,12 +18,10 @@ koji userinfo
    --json      Output information as JSON
 
 
-Display information about a user. Provides their status (enabled or
-blocked), their type (user or group), their kerberos identities if
-any, and a listing of any permissions they have. If the user is
-configured to perform a CG import, this will also be presented.
-
-For groups this command will also show the list of members.
+Display information about a user or group. Provides their status
+(enabled or blocked), their type (user or group), their kerberos
+identities if any, and a listing of any permissions they have. If the
+user is configured to perform CG imports, this will also be presented.
 
 The ``--stats`` option was introduced in version 2.0.0, and provides
 additional output:
@@ -34,6 +32,9 @@ additional output:
 * Last task summary
 * Last build summary
 
+Since version 2.2.0, this command will also show the list of members
+if the specified user ID is actually a group
+
 
 References
 ----------
@@ -41,3 +42,4 @@ References
 * :py:obj:`kojismokydingo.cli.users.ShowUserInfo`
 * :py:func:`kojismokydingo.cli.users.cli_userinfo`
 * :py:func:`kojismokydingo.users.collect_userinfo`
+* :py:func:`kojismokydingo.users.get_group_members`

--- a/docs/commands/userinfo.rst
+++ b/docs/commands/userinfo.rst
@@ -7,7 +7,7 @@ koji userinfo
 
  usage: koji userinfo [-h] [--stats] [--json] USER
 
- Show information about a user
+ Show information about a user or group
 
  positional arguments:
    USER        User name or principal

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -4,7 +4,7 @@ Release Notes
 .. toctree::
    :maxdepth: 1
 
-   release_notes/v2.1.0
+   release_notes/v2.2.0
 
 
 Previous Releases
@@ -13,6 +13,7 @@ Previous Releases
 .. toctree::
    :maxdepth: 1
 
+   release_notes/v2.1.0
    release_notes/v2.0.0
    release_notes/v1.1.0
    release_notes/v1.0.0

--- a/docs/release_notes/v2.2.0.rst
+++ b/docs/release_notes/v2.2.0.rst
@@ -1,0 +1,29 @@
+Koji Smoky Dingo 2.1.0 Release Notes
+====================================
+
+*Unreleased*
+
+Version 2.2.0 continues compatability from 2.0.0, with some additional
+features as noted below
+
+
+Commands
+--------
+
+* Updated the ``userinfo`` command to use an anonymous-compatible
+  group-membership query. Previously the ``getGroupMembers`` call was
+  being used, which always failed because it required the admin
+  permission and the command was anonymous.
+
+
+API
+---
+
+* introduced a new `kojismokydingo.users.get_group_members` function
+
+
+Issues
+------
+
+Closed Issues:
+<https://github.com/obriencj/koji-smoky-dingo/milestone/12?closed=1>

--- a/docs/release_notes/v2.2.0.rst
+++ b/docs/release_notes/v2.2.0.rst
@@ -1,9 +1,9 @@
-Koji Smoky Dingo 2.1.0 Release Notes
+Koji Smoky Dingo 2.2.0 Release Notes
 ====================================
 
 *Unreleased*
 
-Version 2.2.0 continues compatability from 2.0.0, with some additional
+Version 2.2.0 continues compatability from 2.1.0, with some additional
 features as noted below
 
 
@@ -11,15 +11,17 @@ Commands
 --------
 
 * Updated the ``userinfo`` command to use an anonymous-compatible
-  group-membership query. Previously the ``getGroupMembers`` call was
+  group membership query. Previously the ``getGroupMembers`` call was
   being used, which always failed because it required the admin
-  permission and the command was anonymous.
+  permission and the command was anonymous. New implementation uses
+  ``queryHistory``
 
 
 API
 ---
 
 * introduced a new `kojismokydingo.users.get_group_members` function
+* fixed some missing ``__all__`` exports in `kojismokydingo.types`
 
 
 Issues

--- a/kojismokydingo.spec
+++ b/kojismokydingo.spec
@@ -13,8 +13,8 @@
 
 
 %global srcname kojismokydingo
-%global srcver 2.1.0
-%global srcrel 1
+%global srcver 2.1.1
+%global srcrel 0
 
 
 Summary: Koji Smoky Dingo
@@ -135,6 +135,9 @@ Koji Smoky Dingo
 
 
 %changelog
+* Wed Aug 30 2023 Christopher O'Brien <obriencj@gmail.com> - 2.1.1-0
+- See the v2.1.1 release notes for a full list of changes
+
 * Fri Aug 11 2023 Christopher O'Brien <obriencj@gmail.com> - 2.1.0-1
 - See the v2.1.0 release notes for a full list of changes
 

--- a/kojismokydingo.spec
+++ b/kojismokydingo.spec
@@ -13,7 +13,7 @@
 
 
 %global srcname kojismokydingo
-%global srcver 2.1.1
+%global srcver 2.2.0
 %global srcrel 0
 
 
@@ -135,8 +135,8 @@ Koji Smoky Dingo
 
 
 %changelog
-* Wed Aug 30 2023 Christopher O'Brien <obriencj@gmail.com> - 2.1.1-0
-- See the v2.1.1 release notes for a full list of changes
+* Sat Sep 09 2023 Christopher O'Brien <obriencj@gmail.com> - 2.2.0-0
+- See the v2.2.0 release notes for a full list of changes
 
 * Fri Aug 11 2023 Christopher O'Brien <obriencj@gmail.com> - 2.1.0-1
 - See the v2.1.0 release notes for a full list of changes

--- a/kojismokydingo/cli/users.py
+++ b/kojismokydingo/cli/users.py
@@ -24,7 +24,7 @@ from koji import ClientSession
 from operator import itemgetter
 from typing import Optional, Union
 
-from . import AnonSmokyDingo, int_or_str, pretty_json
+from . import AnonSmokyDingo, SmokyDingo, int_or_str, pretty_json
 from ..types import (
     AuthType, TaskState, UserInfo, UserSpec, UserStatus, UserType, )
 from ..users import (

--- a/kojismokydingo/cli/users.py
+++ b/kojismokydingo/cli/users.py
@@ -190,7 +190,7 @@ def cli_userinfo(
                   f" {bdat['creation_time'].split('.')[0]}")
 
 
-class ShowUserInfo(AnonSmokyDingo):
+class ShowUserInfo(SmokyDingo):
 
     group = "info"
     description = "Show information about a user"

--- a/kojismokydingo/cli/users.py
+++ b/kojismokydingo/cli/users.py
@@ -24,7 +24,7 @@ from koji import ClientSession
 from operator import itemgetter
 from typing import Optional, Union
 
-from . import AnonSmokyDingo, SmokyDingo, int_or_str, pretty_json
+from . import AnonSmokyDingo, int_or_str, pretty_json
 from ..types import (
     AuthType, TaskState, UserInfo, UserSpec, UserStatus, UserType, )
 from ..users import (
@@ -170,7 +170,7 @@ def cli_userinfo(
     if members:
         print("Members:")
         for member in sorted(members, key=lambda m: m.get("name")):
-            print(f"{member['name']} [{member['id']}]")
+            print(f"  {member['name']} [{member['id']}]")
 
     data = userinfo.get("statistics", None)
     if data:
@@ -190,10 +190,10 @@ def cli_userinfo(
                   f" {bdat['creation_time'].split('.')[0]}")
 
 
-class ShowUserInfo(SmokyDingo):
+class ShowUserInfo(AnonSmokyDingo):
 
     group = "info"
-    description = "Show information about a user"
+    description = "Show information about a user or group"
 
 
     def arguments(self, parser):

--- a/kojismokydingo/types.py
+++ b/kojismokydingo/types.py
@@ -65,6 +65,8 @@ __all__ = (
     "DecoratedHostInfos",
     "DecoratedTagExtra",
     "DecoratedTagExtras",
+    "DecoratedPermInfo",
+    "DecoratedUserInfo",
     "GOptions",
     "HistoryEntry",
     "HostInfo",

--- a/kojismokydingo/users.py
+++ b/kojismokydingo/users.py
@@ -109,8 +109,9 @@ def get_group_members(
         user: Union[int, str]) -> List[UserInfo]:
 
     """
-    An anonymous version of the admin-only getGroupMembers hub API
-    call. Uses queryHistory to gather still-active group additions
+    An anonymous version of the admin-only ``getGroupMembers`` hub
+    API call. Uses ``queryHistory`` to gather still-active group
+    additions
 
     :param session: an active koji client session
 

--- a/kojismokydingo/users.py
+++ b/kojismokydingo/users.py
@@ -20,13 +20,13 @@ Koji Smoki Dingo - users and permissions
 """
 
 
-from koji import ClientSession, ParameterError
+from koji import ClientSession, GenericError, ParameterError
 from operator import itemgetter
 from time import asctime, localtime
 from typing import List, Optional, Union, cast
 
 from . import (
-    NoSuchContentGenerator, NoSuchPermission,
+    NoSuchContentGenerator, NoSuchPermission, NoSuchUser,
     as_userinfo, bulk_load_users, )
 from .types import (
     CGInfo, DecoratedPermInfo, DecoratedUserInfo, NamedCGInfo,
@@ -39,7 +39,7 @@ __all__ = (
     "collect_perminfo",
     "collect_userinfo",
     "collect_userstats",
-    "get_group_memebers",
+    "get_group_members",
 )
 
 
@@ -188,7 +188,7 @@ def collect_userinfo(
 
     elif ut == UserType.GROUP:
         # userinfo["members"] = session.getGroupMembers(uid)
-        userinfo["members"] = _get_group_members(session, uid)
+        userinfo["members"] = get_group_members(session, uid)
 
     return userinfo
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [metadata]
 name = kojismokydingo
-version = 2.1.1
+version = 2.2.0
 description =  A collection of Koji client plugins and utils
 
 author = Christopher O'Brien
@@ -121,8 +121,8 @@ test = nosetests
 # some of the configuration for sphinx. The rest of it lives over in
 # docs/conf.py
 
-version = 2.1
-release = 2.1.1
+version = 2.2
+release = 2.2.0
 
 project = kojismokydingo
 copyright = 2020-2023, Christopher O'Brien

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@
 
 [metadata]
 name = kojismokydingo
-version = 2.1.0
+version = 2.1.1
 description =  A collection of Koji client plugins and utils
 
 author = Christopher O'Brien
@@ -122,7 +122,7 @@ test = nosetests
 # docs/conf.py
 
 version = 2.1
-release = 2.1.0
+release = 2.1.1
 
 project = kojismokydingo
 copyright = 2020-2023, Christopher O'Brien


### PR DESCRIPTION
adds a new `get_group_members` function which wraps the `queryHistory` API. This is anonymous, compared to the admin-only `getGroupMembers` API.

Closes #143 