### PR TITLE
move away from build_sphinx command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,12 +48,18 @@ build: clean-built report-python flake8	## Produces a wheel using the default sy
 
 
 install: build	## Installs using the default python for the current user
+ifeq ($(UID),"0")
 	@$(PYTHON) -B -m pip.__main__ \
-		install --no-deps --user -I \
+		install -I \
+		dist/$(PROJECT)-$(VERSION)-py3-none-any.whl
+else
+	@$(PYTHON) -B -m pip.__main__ \
+		install --user -I \
 		dist/$(PROJECT)-$(VERSION)-py3-none-any.whl
 	@mkdir -p ~/.koji/plugins
 	@rm -f ~/.koji/plugins/kojismokydingometa.py
 	@ln -s `$(PYTHON) -c 'import koji_cli_plugins.kojismokydingometa as ksdm ; print(ksdm.__file__);'` ~/.koji/plugins/kojismokydingometa.py
+endif
 
 
 ##@ Cleanup
@@ -62,7 +68,7 @@ tidy:	## Removes stray eggs and .pyc files
 	@rm -rf *.egg-info
 	$(call checkfor,find)
 	@find -H . \
-		\( -iname '.$(TOX)' -o -iname '.eggs' -prune \) -o \
+		\( -iname '.tox' -o -iname '.eggs' -prune \) -o \
 		\( -type d -iname '__pycache__' -exec rm -rf {} + \) -o \
 		\( -type f -iname '*.pyc' -exec rm -f {} + \)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,23 @@
 
 
+def load_setup():
+    from configparser import ConfigParser
+
+    conf = ConfigParser()
+    conf.read(["../setup.cfg"])
+
+    glbls = globals()
+    metadata = conf['metadata']
+
+    glbls['project'] = metadata['name']
+    glbls['release'] = metadata['version']
+    glbls['version'] = '.'.join(release.split('.')[:2])
+    glbls['author'] = metadata['author']
+    glbls['copyright'] = f"{metadata['copyright_years']}, {author}"
+
+load_setup()
+
+
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosectionlabel',
@@ -159,8 +177,8 @@ numpydoc_class_members_toctree = False
 # --- Manpage Settings
 
 man_pages = [
-    ('commands', 'kojismokydingo', "Koji Smoky Dingo Plugin Commands",
-     ["Christopher O'Brien"], 7),
+    ('commands', project, "Koji Smoky Dingo Plugin Commands",
+     [author], 7),
 ]
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,8 @@ description =  A collection of Koji client plugins and utils
 author = Christopher O'Brien
 author_email = obriencj@gmail.com
 
+copyright_years = 2020-2023
+
 license = GNU General Public License v3 (GPLv3)
 license_files =
   LICENSE
@@ -115,21 +117,6 @@ kojismokydingo =
 # most convenient and available way to get started with unit testing.
 
 test = nosetests
-
-
-[build_sphinx]
-# some of the configuration for sphinx. The rest of it lives over in
-# docs/conf.py
-
-version = 2.2
-release = 2.2.0
-
-project = kojismokydingo
-copyright = 2020-2023, Christopher O'Brien
-
-build-dir = build/sphinx
-builder = dirhtml html
-source-dir = docs
 
 
 [tox:tox]
@@ -267,15 +254,17 @@ skip_install = True
 
 basepython = python3.9
 
+# somewhere, some idiot is proud of the removal of the build_sphinx
+# setuptools integration.
 commands =
-  python -B setup.py build_sphinx
+  python -B -m sphinx.cmd.build -b dirhtml \
+    docs build/sphinx/dirhtml
 
-# sphinx 7 not only doesn't have a build_sphinx command, but it also
-# completely ignores the settings in setup.cfg, therefore it can EABOD
-# and we'll keep using the older one via setuptools, drinking in the
-# hot deprecation tears of the setuptools devs like a fine sake
+  python -B -m sphinx.cmd.build -b html \
+    docs build/sphinx/html
+
 deps =
-  sphinx<7
+  sphinx
 
 
 [testenv:build]

--- a/setup.cfg
+++ b/setup.cfg
@@ -120,7 +120,7 @@ test = nosetests
 
 
 [tox:tox]
-envlist = flake8,mypy,bandit,twine,py{36,37,38,39,310,311},coverage
+envlist = flake8,mypy,bandit,twine,py{37,38,39,310,311},coverage
 skip_missing_interpreters = true
 
 


### PR DESCRIPTION
* move sphinx configuration out of setup.cfg
* add code in docs/config.py to look up project metadata values to avoid repetition
* drops py36 from default env list, since the env is frequently broken

Closes #150 