### PR TITLE
rpm evr_compare caret support

### DIFF
--- a/docs/release_notes/v2.2.0.rst
+++ b/docs/release_notes/v2.2.0.rst
@@ -24,6 +24,19 @@ API
 * fixed some missing ``__all__`` exports in `kojismokydingo.types`
 
 
+Bugfix
+------
+
+* added missing caret support to `kojismokydingo.rpm.evr_compare`
+
+
+Other
+-----
+
+* moved documentation build into a github action workflow, removing
+  gh-pages submodule and related Makefile targets
+
+
 Issues
 ------
 

--- a/kojismokydingo/rpm.py
+++ b/kojismokydingo/rpm.py
@@ -34,7 +34,7 @@ __all__ = (
 )
 
 
-_rpm_str_split_re = re.compile(r"(~?(?:\d+|[a-zA-Z]+))").split
+_rpm_str_split_re = re.compile(r"([~^]?(?:\d+|[a-zA-Z]+))").split
 
 
 def _rpm_str_split(s: str) -> Tuple[str]:
@@ -43,7 +43,7 @@ def _rpm_str_split(s: str) -> Tuple[str]:
     """
 
     return tuple(i for i in _rpm_str_split_re(s)  # type: ignore
-                 if (i.isalnum() or i.startswith("~")))
+                 if i and (i.isalnum() or (i[0] in "~^")))
 
 
 def _rpm_str_compare(leftstr: str, rightstr: str) -> int:
@@ -83,6 +83,20 @@ def _rpm_str_compare(leftstr: str, rightstr: str) -> int:
         elif rp.startswith("~"):
             # left is not tilde, but right is, therefore left is greater
             return 1
+
+        elif lp.startswith("^"):
+            # left is caret
+
+            if rp.startswith("^"):
+                lp = lp[1:]
+                rp = rp[1:]
+
+            else:
+                return -1 if rp else 1
+
+        elif rp.startswith("^"):
+            # left is not caret, nor tilde, but right is caret
+            return 1 if lp else -1
 
         # Special comparison for digits vs. alphabetical
         if lp.isdigit():

--- a/tests/rpm.py
+++ b/tests/rpm.py
@@ -79,6 +79,7 @@ RPM_STR_CMP_1 = [
     ("1.1", "1.0"),
     ("1.1", "1.A"),
     ("1.B", "1.A"),
+    ("1.0", "1.0~beta"),
     ("1.1", "1.0~beta"),
     ("1.1", "1.1~beta"),
     ("1.2~beta", "1.1"),
@@ -90,6 +91,20 @@ RPM_STR_CMP_1 = [
     ("2.0", "2"),
     ("2.0", "2~beta"),
     ("2beta", "2~beta"),
+
+    ("1.0^1", "1.0~beta"),
+    ("1.0^1", "1.0"),
+    ("1.0.1~beta", "1.0^1"),
+    ("1.0.1", "1.0^1"),
+
+    ("1.0.0^1", "1.0~0"),
+    ("1.0.0^1", "1.0^0"),
+    ("1.0.0^1", "1.0.0"),
+
+    ("1.0.1^0", "1.0~1"),
+    ("1.0.1^0", "1.0^1"),
+    ("1.0.1^0", "1.0.1"),
+    ("1.0.1^1", "1.0.1^0"),
 ]
 
 
@@ -100,44 +115,58 @@ class TestEVRSort(TestCase):
         # rpm lib. However, not all systems have rpmlib available, so
         # we omit these tests in those environments.
 
-        def test_rpm_compare_ver_0(self):
+        def test_rpmlib_compare_ver_0(self):
             for vl, vr in RPM_STR_CMP_0:
-                self.assertEqual(compareVer(vl, vr), 0)
-                self.assertEqual(compareVer(vr, vl), 0)
+                msg = f"left: {vl!r}, right: {vr!r}"
+                self.assertEqual(compareVer(vl, vr), 0, msg)
+                msg = f"left: {vr!r}, right: {vl!r}"
+                self.assertEqual(compareVer(vr, vl), 0, msg)
 
 
-        def test_rpm_compare_ver_1(self):
+        def test_rpmlib_compare_ver_1(self):
             for vl, vr in RPM_STR_CMP_1:
+                msg = f"left: {vl!r}, right: {vr!r}"
                 self.assertEqual(compareVer(vl, vr), 1)
+                msg = f"left: {vr!r}, right: {vl!r}"
                 self.assertEqual(compareVer(vr, vl), -1)
 
 
-    def test_rpm_str_cmp_0(self):
+    def test_str_cmp_0(self):
         for vl, vr in RPM_STR_CMP_0:
-            self.assertEqual(_rpm_str_compare(vl, vr), 0)
-            self.assertEqual(_rpm_str_compare(vr, vl), 0)
+            msg = f"left: {vl!r}, right: {vr!r}"
+            self.assertEqual(_rpm_str_compare(vl, vr), 0, msg)
+            msg = f"left: {vr!r}, right: {vl!r}"
+            self.assertEqual(_rpm_str_compare(vr, vl), 0, msg)
 
 
-    def test_rpm_str_cmp_1(self):
+    def test_str_cmp_1(self):
         for vl, vr in RPM_STR_CMP_1:
-            self.assertEqual(_rpm_str_compare(vl, vr), 1)
-            self.assertEqual(_rpm_str_compare(vr, vl), -1)
+            msg = f"left: {vl!r}, right: {vr!r}"
+            self.assertEqual(_rpm_str_compare(vl, vr), 1, msg)
+            msg = f"left: {vr!r}, right: {vl!r}"
+            self.assertEqual(_rpm_str_compare(vr, vl), -1, msg)
 
 
-    def test_rpm_evr_compare_cmp_0(self):
+    def test_evr_compare_cmp_0(self):
         for vl, vr in RPM_STR_CMP_0:
             evr_l = ("0", vl, "1")
             evr_r = ("0", vr, "1")
-            self.assertEqual(evr_compare(evr_l, evr_r), 0)
-            self.assertEqual(evr_compare(evr_r, evr_l), 0)
+
+            msg = f"left: {evr_l!r}, right: {evr_r!r}"
+            self.assertEqual(evr_compare(evr_l, evr_r), 0, msg)
+            msg = f"left: {evr_r!r}, right: {evr_l!r}"
+            self.assertEqual(evr_compare(evr_r, evr_l), 0, msg)
 
 
-    def test_rpm_evr_compare_cmp_1(self):
+    def test_evr_compare_cmp_1(self):
         for vl, vr in RPM_STR_CMP_1:
             evr_l = ("0", vl, "1")
             evr_r = ("0", vr, "1")
-            self.assertEqual(evr_compare(evr_l, evr_r), 1)
-            self.assertEqual(evr_compare(evr_r, evr_l), -1)
+
+            msg = f"left: {evr_l!r}, right: {evr_r!r}"
+            self.assertEqual(evr_compare(evr_l, evr_r), 1, msg)
+            msg = f"left: {evr_r!r}, right: {evr_l!r}"
+            self.assertEqual(evr_compare(evr_r, evr_l), -1, msg)
 
 
 NEVRA_SPLITS = [
@@ -162,6 +191,11 @@ NEVRA_SPLITS = [
      (None, "32", "9.10.2", "2.P1.fc22", "x86_64")),
     ("32:9.10.2",
      (None, "32", "9.10.2", None, None)),
+
+    ("package-1.0.0~beta1-203.x86_64",
+     ("package", None, "1.0.0~beta1", "203", "x86_64")),
+    ("package-1.0.0^post1-203.x86_64",
+     ("package", None, "1.0.0^post1", "203", "x86_64")),
 
     ("",
      ("", None, None, None, None)),
@@ -190,6 +224,11 @@ NEVR_SPLITS = [
      (None, "32", "9.10.2", "2.P1.fc22.x86_64")),
     ("32:9.10.2",
      (None, "32", "9.10.2", None)),
+
+    ("package-1.0.0~beta1-203",
+     ("package", None, "1.0.0~beta1", "203")),
+    ("package-1.0.0^post1-203",
+     ("package", None, "1.0.0^post1", "203")),
 
     ("",
      ("", None, None, None)),


### PR DESCRIPTION
Adds caret handling in RPM EVR comparisons in the `kojismokydingo.rpm.evr_compare` function

Closes #142