### PR TITLE
use new hub_version session property if available

### DIFF
--- a/docs/release_notes/v2.2.0.rst
+++ b/docs/release_notes/v2.2.0.rst
@@ -26,6 +26,10 @@ API
 * introduced a new `kojismokydingo.users.get_group_members` function
 * introduced a new `kojismokydingo.users.get_user_groups` function
 * fixed some missing ``__all__`` exports in `kojismokydingo.types`
+* the `kojismokydingo.hub_version` function will work with the new
+  `koji.hub_version_str` property, which is populated from a new value
+  in http headers on responses from the hub. This potentially saves us
+  the explicit ``getKojiVersion`` call on newer deployments
 
 
 Meta Plugin
@@ -54,6 +58,8 @@ Other
 * migrated away from the ``build_sphinx`` setuptools command
 * introduced nightly CI that runs against the upstream git version of
   koji, in order to catch any additional API changes early on
+* added more static analysis checking and a special proxytype plugin,
+  and moved from the ``stubs`` directory to the ``mypy`` directory
 
 
 Issues

--- a/mypy/koji/__init__.pyi
+++ b/mypy/koji/__init__.pyi
@@ -171,6 +171,20 @@ class ClientSession:
     multicall: "MultiCallHack"
     opts: Dict[str, Any]
 
+    @property
+    def hub_version(self) -> Tuple[int, ...]:
+        """
+        :since: koji 1.35
+        """
+        ...
+
+    @property
+    def hub_version_str(self) -> str:
+        """
+        :since: koji 1.35
+        """
+        ...
+
     def __init__(
             self,
             baseurl: str,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -214,13 +214,13 @@ class TestVersionCheck(TestCase):
         self.assertFalse(version_check(sess, "1.26"))
         self.assertFalse(version_check(sess, (1, 26)))
         self.assertFalse(version_check(sess, (1, 27)))
-        self.assertEqual(vars(sess)["__hub_version"], (1, 25))
+        self.assertEqual(vars(sess)["__ksd_hub_version"], (1, 25))
         self.assertEqual(send.call_count, 1)
 
         sess, send = self.session([self.ge()])
         self.assertFalse(version_check(sess, (1, 23)))
         self.assertFalse(version_check(sess, (1, 24)))
-        self.assertEqual(vars(sess)["__hub_version"], (1, 22))
+        self.assertEqual(vars(sess)["__ksd_hub_version"], (1, 22))
         self.assertEqual(send.call_count, 1)
 
 
@@ -230,19 +230,19 @@ class TestVersionCheck(TestCase):
         self.assertTrue(version_check(sess, "1.23"))
         self.assertTrue(version_check(sess, (1, 23)))
         self.assertTrue(version_check(sess, (1, 24)))
-        self.assertEqual(vars(sess)["__hub_version"], (1, 24))
+        self.assertEqual(vars(sess)["__ksd_hub_version"], (1, 24))
         self.assertEqual(send.call_count, 1)
 
         sess, send = self.session(["1.25"])
         self.assertTrue(version_check(sess, (1, 24)))
         self.assertTrue(version_check(sess, (1, 25)))
-        self.assertEqual(vars(sess)["__hub_version"], (1, 25))
+        self.assertEqual(vars(sess)["__ksd_hub_version"], (1, 25))
         self.assertEqual(send.call_count, 1)
 
         sess, send = self.session([self.ge()])
         self.assertTrue(version_check(sess, (1, 22)))
         self.assertTrue(version_check(sess, (1, 22)))
-        self.assertEqual(vars(sess)["__hub_version"], (1, 22))
+        self.assertEqual(vars(sess)["__ksd_hub_version"], (1, 22))
         self.assertEqual(send.call_count, 1)
 
 
@@ -251,13 +251,13 @@ class TestVersionCheck(TestCase):
         sess, send = self.session(["1.25"])
         self.assertRaises(FeatureUnavailable, version_require, sess, (1, 26))
         self.assertRaises(FeatureUnavailable, version_require, sess, (1, 27))
-        self.assertEqual(vars(sess)["__hub_version"], (1, 25))
+        self.assertEqual(vars(sess)["__ksd_hub_version"], (1, 25))
         self.assertEqual(send.call_count, 1)
 
         sess, send = self.session([self.ge()])
         self.assertRaises(FeatureUnavailable, version_require, sess, (1, 23))
         self.assertRaises(FeatureUnavailable, version_require, sess, (1, 24))
-        self.assertEqual(vars(sess)["__hub_version"], (1, 22))
+        self.assertEqual(vars(sess)["__ksd_hub_version"], (1, 22))
         self.assertEqual(send.call_count, 1)
 
 
@@ -266,19 +266,19 @@ class TestVersionCheck(TestCase):
         sess, send = self.session(["1.24"])
         self.assertTrue(version_require(sess, (1, 23)))
         self.assertTrue(version_require(sess, (1, 24)))
-        self.assertEqual(vars(sess)["__hub_version"], (1, 24))
+        self.assertEqual(vars(sess)["__ksd_hub_version"], (1, 24))
         self.assertEqual(send.call_count, 1)
 
         sess, send = self.session(["1.25"])
         self.assertTrue(version_require(sess, (1, 24)))
         self.assertTrue(version_require(sess, (1, 25)))
-        self.assertEqual(vars(sess)["__hub_version"], (1, 25))
+        self.assertEqual(vars(sess)["__ksd_hub_version"], (1, 25))
         self.assertEqual(send.call_count, 1)
 
         sess, send = self.session([self.ge()])
         self.assertTrue(version_require(sess, (1, 22)))
         self.assertTrue(version_require(sess, (1, 22)))
-        self.assertEqual(vars(sess)["__hub_version"], (1, 22))
+        self.assertEqual(vars(sess)["__ksd_hub_version"], (1, 22))
         self.assertEqual(send.call_count, 1)
 
 
@@ -514,8 +514,8 @@ class TestAsUserinfo(TestCase):
         self.assertEqual(send.call_args_list[0][0], (key, False, True))
 
         sess_vars = vars(sess)
-        self.assertTrue("__new_get_user" in sess_vars)
-        self.assertTrue(sess_vars["__new_get_user"])
+        self.assertTrue("__ksd_new_get_user" in sess_vars)
+        self.assertTrue(sess_vars["__ksd_new_get_user"])
 
         res = as_userinfo(sess, key)
         self.assertEqual(res, self.DATA)
@@ -530,8 +530,8 @@ class TestAsUserinfo(TestCase):
         self.assertEqual(send.call_args_list[1][0], (key,))
 
         sess_vars = vars(sess)
-        self.assertTrue("__new_get_user" in sess_vars)
-        self.assertFalse(sess_vars["__new_get_user"])
+        self.assertTrue("__ksd_new_get_user" in sess_vars)
+        self.assertFalse(sess_vars["__ksd_new_get_user"])
 
         res = as_userinfo(sess, key)
         self.assertEqual(res, self.DATA)


### PR DESCRIPTION
Have the hub_version function use the new hub_version property if it is available. This will allow us to get version checks for free, as the new property skims the version value out of a header in XMLRPC responses.

Closes #175 